### PR TITLE
FromPayment method added

### DIFF
--- a/payment/payment.go
+++ b/payment/payment.go
@@ -32,7 +32,7 @@ func FromPublicKey(pubkey *btcec.PublicKey, network *network.Network) Payment {
 
 // FromPayment creates a Payment struct from a another Payment
 func FromPayment(payment *Payment, network *network.Network) Payment {
-	buf := payment.Hash
+	buf := payment.Script
 	hash := hash160(buf)
 	return Payment{network, payment.PublicKey, hash, nil, nil, nil}
 }

--- a/payment/payment.go
+++ b/payment/payment.go
@@ -30,6 +30,13 @@ func FromPublicKey(pubkey *btcec.PublicKey, network *network.Network) Payment {
 	return Payment{network, pubkey, hash, nil, nil, nil}
 }
 
+// FromPayment creates a Payment struct from a another Payment
+func FromPayment(payment *Payment, network *network.Network) Payment {
+	buf := payment.Hash
+	hash := hash160(buf)
+	return Payment{network, payment.PublicKey, hash, nil, nil, nil}
+}
+
 // PubKeyHash is a method of the Payment struct to derive a base58 p2pkh address
 func (p *Payment) PubKeyHash() string {
 	payload := &address.Base58{p.Network.PubKeyHash, p.Hash}

--- a/payment/payment.go
+++ b/payment/payment.go
@@ -31,10 +31,10 @@ func FromPublicKey(pubkey *btcec.PublicKey, network *network.Network) Payment {
 }
 
 // FromPayment creates a Payment struct from a another Payment
-func FromPayment(payment *Payment, network *network.Network) Payment {
+func FromPayment(payment *Payment) Payment {
 	buf := payment.Script
 	hash := hash160(buf)
-	return Payment{network, payment.PublicKey, hash, nil, nil, nil}
+	return Payment{payment.Network, payment.PublicKey, hash, nil, nil, nil}
 }
 
 // PubKeyHash is a method of the Payment struct to derive a base58 p2pkh address


### PR DESCRIPTION
Before this, there was no option to create Payment based on another Payment.

This introduces a new Factory method for the creation of a Payment based on another Payment. Internally method is setting hash, of a new Payment, by taking hash from the input and re-hash it.

This closes #9 

Please, @altafan, review this.