### PR TITLE
p2wsh address

### DIFF
--- a/payment/payment.go
+++ b/payment/payment.go
@@ -47,15 +47,19 @@ func FromPublicKey(pubkey *btcec.PublicKey, net *network.Network) *Payment {
 
 // FromPayment creates a Payment struct from a another Payment
 func FromPayment(payment *Payment) (*Payment, error) {
-	if payment.Script == nil {
-		return nil, errors.New("script can't be nil")
+	if payment.Script == nil || len(payment.Script) == 0 {
+		return nil, errors.New("payment's script can't be empty or nil")
 	}
 	redeem := &Payment{payment.Network, payment.PublicKey, payment.Hash, payment.BlindingKey, payment.Redeem, payment.Script, payment.WitnessHash}
-	return &Payment{payment.Network, nil, hash160(redeem.Script), nil, redeem, nil, nil}, nil
+	witnessHash := sha256.Sum256(redeem.Script)
+	return &Payment{payment.Network, payment.PublicKey, hash160(redeem.Script), payment.BlindingKey, redeem, payment.Script, witnessHash[:]}, nil
 }
 
 // FromPayment creates a nested Payment struct from script
 func FromScript(script []byte, net *network.Network) (*Payment, error) {
+	if script == nil || len(script) == 0 {
+		return nil, errors.New("payment's script can't be empty or nil")
+	}
 	var tmpNet *network.Network
 	if net == nil {
 		tmpNet = &network.Liquid
@@ -68,40 +72,55 @@ func FromScript(script []byte, net *network.Network) (*Payment, error) {
 
 // PubKeyHash is a method of the Payment struct to derive a base58 p2pkh address
 func (p *Payment) PubKeyHash() string {
+	if p.Hash == nil || len(p.Hash) == 0 {
+		errors.New("payment's hash can't be empty or nil")
+	}
 	payload := &address.Base58{p.Network.PubKeyHash, p.Hash}
 	addr := address.ToBase58(payload)
 	return addr
 }
 
 // ScriptHash is a method of the Payment struct to derive a base58 p2sh address
-func (p *Payment) ScriptHash() string {
+func (p *Payment) ScriptHash() (string, error) {
+	if p.Hash == nil || len(p.Hash) == 0 {
+		return "", errors.New("payment's hash can't be empty or nil")
+	}
 	payload := &address.Base58{p.Network.ScriptHash, p.Hash}
 	addr := address.ToBase58(payload)
-	return addr
+	return addr, nil
 }
 
 // WitnessPubKeyHash is a method of the Payment struct to derive a base58 p2wpkh address
-func (p *Payment) WitnessPubKeyHash() string {
+func (p *Payment) WitnessPubKeyHash() (string, error) {
+	if p.Hash == nil || len(p.Hash) == 0 {
+		return "", errors.New("payment's hash can't be empty or nil")
+	}
 	//Here the Version for wpkh is always 0
 	version := byte(0x00)
 	payload := &address.Bech32{p.Network.Bech32, version, p.Hash}
 	addr, err := address.ToBech32(payload)
 	if err != nil {
-		return ""
+		return "", nil
 	}
-	return addr
+	return addr, nil
 }
 
 // WitnessScriptHash is a method of the Payment struct to derive a base58 p2wsh address
-func (p *Payment) WitnessScriptHash() string {
-	//Here the Version for wpkh is always 0
+func (p *Payment) WitnessScriptHash() (string, error) {
+	if p.Script == nil || len(p.Script) == 0 {
+		return "", errors.New("payment's script can't be empty or nil")
+	}
+	if p.WitnessHash == nil || len(p.WitnessHash) == 0 {
+		return "", errors.New("payment's witnessHash can't be empty or nil")
+	}
+
 	version := byte(0x00)
 	payload := &address.Bech32{p.Network.Bech32, version, p.WitnessHash}
 	addr, err := address.ToBech32(payload)
 	if err != nil {
-		return ""
+		return "", err
 	}
-	return addr
+	return addr, nil
 }
 
 // Calculate the hash of hasher over buf.

--- a/payment/payment_test.go
+++ b/payment/payment_test.go
@@ -29,3 +29,11 @@ func TestSegwitAddress(t *testing.T) {
 		t.Errorf("TestSegwitAddress: error when encoding segwit")
 	}
 }
+
+func TestP2WSH(t *testing.T) {
+	_, publicKey := btcec.PrivKeyFromBytes(btcec.S256(), privateKeyBytes)
+	pay := payment.FromPublicKey(publicKey, &network.Regtest)
+	if pay.WitnessScriptHash() != "ert1q5kvuxm0d64ecvmh2kklku6afw03g849af8jfac3t6vgjwrar8xsseary2s" {
+		t.Errorf("TestSegwitAddress: error when encoding segwit")
+	}
+}

--- a/payment/payment_test.go
+++ b/payment/payment_test.go
@@ -25,15 +25,50 @@ func TestSegwitAddress(t *testing.T) {
 	_, publicKey := btcec.PrivKeyFromBytes(btcec.S256(), privateKeyBytes)
 
 	pay := payment.FromPublicKey(publicKey, &network.Regtest)
-	if pay.WitnessPubKeyHash() != "ert1qlg343tpldc4wvjxn3jdq2qs35r8j5yd5kjfrrt" {
+	p2pkh, err := pay.WitnessPubKeyHash()
+	if err != nil {
+		t.Error(err)
+	}
+	if p2pkh != "ert1qlg343tpldc4wvjxn3jdq2qs35r8j5yd5kjfrrt" {
 		t.Errorf("TestSegwitAddress: error when encoding segwit")
 	}
 }
 
-func TestP2WSH(t *testing.T) {
+func TestScriptHash(t *testing.T) {
 	_, publicKey := btcec.PrivKeyFromBytes(btcec.S256(), privateKeyBytes)
-	pay := payment.FromPublicKey(publicKey, &network.Regtest)
-	if pay.WitnessScriptHash() != "ert1q5kvuxm0d64ecvmh2kklku6afw03g849af8jfac3t6vgjwrar8xsseary2s" {
+	p2wpkh := payment.FromPublicKey(publicKey, &network.Regtest)
+	pay, err := payment.FromPayment(p2wpkh)
+	p2sh, err := pay.ScriptHash()
+	if err != nil {
+		t.Error(err)
+	}
+	if p2sh != "XZavBojABpfXhPWkw7y9YYFNAezUHZR47m" {
+		t.Errorf("TestScriptHash: error when encoding script hash")
+	}
+}
+
+func TestP2WSH(t *testing.T) {
+	redeemScript := "52410479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b84104c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee51ae168fea63dc339a3c58419466ceaeef7f632653266d0e1236431a950cfe52a52ae"
+	redeemScriptBytes, err := hex.DecodeString(redeemScript)
+	if err != nil {
+		t.Error(err)
+	}
+
+	p2ms, err := payment.FromScript(redeemScriptBytes, &network.Regtest)
+	if err != nil {
+		t.Error(err)
+	}
+
+	p2wsh, err := payment.FromPayment(p2ms)
+	if err != nil {
+		t.Error(err)
+	}
+
+	p2wshAddress, err := p2wsh.WitnessScriptHash()
+	if err != nil {
+		t.Error(err)
+	}
+	if p2wshAddress != "ert1q2z45rh444qmeand48lq0wp3jatxs2nzh492ds9s5yscv2pplxwesajz7q3" {
 		t.Errorf("TestSegwitAddress: error when encoding segwit")
 	}
 }


### PR DESCRIPTION
Before there was no option to get p2wsh address.

After the method WitnessScriptHash added user of a package can get payment's p2wsh address.
FromPublicKey factory method is updated so that it contains WitnessHash.

It closes #12 

Please @altafan can you review this?