### PR TITLE
Readme: goreportcard.com badge; go get command; roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,18 @@
 # go-elements
 
 [![Build Status](https://travis-ci.com/vulpemventures/go-elements.svg?branch=master)](https://travis-ci.com/vulpemventures/go-elements)
+[![Go Report Card](https://goreportcard.com/badge/github.com/vulpemventures/go-elements)](https://goreportcard.com/report/github.com/vulpemventures/go-elements)
 [![Bitcoin Donate](https://badgen.net/badge/Bitcoin/Donate/F7931A?icon=bitcoin)](https://blockstream.info/address/3MdERN32qiMnQ68bSSee5CXQkrSGx1iStr)
 
 Go support for confidential transactions on Elements-based blockchains
 
-**The package is currently being developed. DO NOT USE IT**
+**The package is currently being developed.** For stable versions, you must refer to the [latest release](https://github.com/vulpemventures/go-elements/releases)
+
+## Install
+
+```sh
+$ go get -u github.com/vulpemventures/go-elements
+```
 
 ## 🛣 Roadmap
 
@@ -24,8 +31,8 @@ Go support for confidential transactions on Elements-based blockchains
   - [x] Add confidential fields
   - [x] Serialization for (witness) signature
 - [x] [PSET / Bip174 for Elements](https://github.com/vulpemventures/go-elements/tree/master/pset)
-- [ ] CGO bindings for blech32
-- [ ] CGO bindings for secp256k1-zkp
+- [x] [Blech32](https://github.com/vulpemventures/go-elements/tree/master/blech32)
+- [ ] [CGO bindings for secp256k1-zkp](https://github.com/vulpemventures/go-secp256k1-zkp)
 - [ ] Blinding outs/ Unblinding ins
 - [ ] Slip77
 - [ ] Signing a confidential input (use 0 value amounts to produce the hash for the signature)


### PR DESCRIPTION
This commit updated the Readme adding:

* GoReportCard.com badge
* `go get` command to install the library
* Update the Roadmap checkbox with a link  for `blech32` package