### PR TITLE
Slip77 support

### DIFF
--- a/slip77/data/slip77.json
+++ b/slip77/data/slip77.json
@@ -1,0 +1,16 @@
+{
+  "fromSeed": [
+    {
+      "seed": "c76c4ac4f4e4a00d6b274d5c39c700bb4a7ddc04fbc6f78e85ca75007b5b495f74a9043eeb77bdd53aa6fc3a0e31462270316fa04b8c19114c8798706cd02ac8",
+      "expected": "6c2de18eabeff3f7822bc724ad482bef0557f3e1c1e1c75b7a393a5ced4de616"
+    }
+  ],
+  "deriveKey": [
+    {
+      "masterKey": "6c2de18eabeff3f7822bc724ad482bef0557f3e1c1e1c75b7a393a5ced4de616",
+      "script": "76a914a579388225827d9f2fe9014add644487808c695d88ac",
+      "expectedPrivKey": "4e6e94df28448c7bb159271fe546da464ea863b3887d2eec6afd841184b70592",
+      "expectedPubKey": "0223ef5cf5d1185f86204b9386c8541061a24b6f72fa4a29e3a0b60e1c20ffaf5b"
+    }
+  ]
+}

--- a/slip77/slip77.go
+++ b/slip77/slip77.go
@@ -1,0 +1,69 @@
+package slip77
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/sha512"
+	"errors"
+
+	"github.com/btcsuite/btcd/btcec"
+)
+
+var (
+	domain = []byte("Symmetric key seed")
+	label  = []byte("SLIP-0077")
+	prefix = byte(0)
+)
+
+type Slip77 struct {
+	MasterKey []byte
+}
+
+// FromMasterKey sets the provided master key to the returned instance of Slip77
+func FromMasterKey(masterKey []byte) (*Slip77, error) {
+	if masterKey == nil || len(masterKey) <= 0 {
+		return nil, errors.New("invalid master key")
+	}
+
+	return &Slip77{
+		MasterKey: masterKey,
+	}, nil
+}
+
+// FromSeed derives the master key from the given seed and uses it to create
+// and return a new Slip77 instance
+func FromSeed(seed []byte) (*Slip77, error) {
+	if seed == nil || len(seed) <= 0 {
+		return nil, errors.New("invalid seed")
+	}
+
+	hmacRoot := hmac.New(sha512.New, domain)
+	hmacRoot.Write(seed)
+	root := hmacRoot.Sum(nil)
+
+	hmacMasterKey := hmac.New(sha512.New, root[:32])
+	hmacMasterKey.Write([]byte{prefix})
+	hmacMasterKey.Write(label)
+	masterKey := hmacMasterKey.Sum(nil)
+
+	return FromMasterKey(masterKey[32:])
+}
+
+// DeriveKey derives a private key from the master key of the Slip77 type
+// and a provided script
+func (s *Slip77) DeriveKey(script []byte) (*btcec.PrivateKey, *btcec.PublicKey, error) {
+	if s.MasterKey == nil || len(s.MasterKey) <= 0 {
+		return nil, nil, errors.New("master key must be defined")
+	}
+	if script == nil || len(script) <= 0 {
+		return nil, nil, errors.New("invalid script")
+	}
+
+	hmacKey := hmac.New(sha256.New, s.MasterKey)
+	hmacKey.Write(script)
+	key := hmacKey.Sum(nil)
+
+	privateKey, publicKey := btcec.PrivKeyFromBytes(btcec.S256(), key)
+
+	return privateKey, publicKey, nil
+}

--- a/slip77/slip77_test.go
+++ b/slip77/slip77_test.go
@@ -1,0 +1,71 @@
+package slip77
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFromSeed(t *testing.T) {
+	file, err := ioutil.ReadFile("data/slip77.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var tests map[string]interface{}
+	json.Unmarshal(file, &tests)
+
+	for _, testVector := range tests["fromSeed"].([]interface{}) {
+		v := testVector.(map[string]interface{})
+		seed, _ := hex.DecodeString(v["seed"].(string))
+
+		slip77Node, err := FromSeed(seed)
+		if !assert.NoError(t, err) {
+			t.Fatal(err)
+		}
+
+		expected := v["expected"].(string)
+		assert.Equal(t, expected, hex.EncodeToString(slip77Node.MasterKey))
+	}
+}
+
+func TestDeriveKey(t *testing.T) {
+	file, err := ioutil.ReadFile("data/slip77.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var tests map[string]interface{}
+	json.Unmarshal(file, &tests)
+
+	for _, testVector := range tests["deriveKey"].([]interface{}) {
+		v := testVector.(map[string]interface{})
+		script, _ := hex.DecodeString(v["script"].(string))
+		masterKey, _ := hex.DecodeString(v["masterKey"].(string))
+
+		slip77Node, err := FromMasterKey(masterKey)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		privKey, pubKey, err := slip77Node.DeriveKey(script)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		serializedPrivKey := hex.EncodeToString(privKey.Serialize())
+		serializedPubKey := hex.EncodeToString(pubKey.SerializeCompressed())
+
+		assert.Equal(
+			t,
+			v["expectedPrivKey"].(string),
+			serializedPrivKey,
+		)
+		assert.Equal(
+			t,
+			v["expectedPubKey"].(string),
+			serializedPubKey,
+		)
+	}
+}


### PR DESCRIPTION
This adds a new `slip77` package to the library that enables the user to derive blinding keys from a master key or a bip39 seed, and an output script following the SLIP-0077 specification.

This closes #76.
This closes #77.

@tiero please, review this.