### PR TITLE
WitnessScript field in Payment and fix HashForSignature

### DIFF
--- a/address/address_test.go
+++ b/address/address_test.go
@@ -2,8 +2,11 @@ package address_test
 
 import (
 	"encoding/hex"
-	"github.com/vulpemventures/go-elements/address"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vulpemventures/go-elements/address"
+	"github.com/vulpemventures/go-elements/network"
 )
 
 const (
@@ -156,4 +159,81 @@ func TestFromBlech32_P2WSH(t *testing.T) {
 	if hex.EncodeToString(resProgram) != witProg2 {
 		t.Error("TestFromBlech32_P2WSH: wrong witness program")
 	}
+}
+
+func TestDecodeAddressTypeP2Pkh(t *testing.T) {
+	addr := "Q9863Eah5byyxdBX8zghpooS2x4Ey8XZyc"
+	addressType, err := address.DecodeType(addr, network.Liquid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, address.P2Pkh, addressType)
+}
+
+func TestDecodeAddressTypeP2sh(t *testing.T) {
+	addr := "H5RCjtzndKyzFnVe41yg62T3WViWguyz4M"
+	addressType, err := address.DecodeType(addr, network.Liquid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, address.P2Sh, addressType)
+}
+
+func TestDecodeAddressTypeConfidentialP2Pkh(t *testing.T) {
+	addr := "VTpuLYhJwE8CFm6h1A6DASCaJuRQqkBt6qGfbebSHAUxGXsJMo8wtRvLZYZSWWXt8" +
+		"9jG55pCF4YfxMjh"
+	addressType, err := address.DecodeType(addr, network.Liquid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, address.ConfidentialP2Pkh, addressType)
+}
+
+func TestDecodeAddressTypeConfidentialP2sh(t *testing.T) {
+	addr := "VJLDHFUbw8oPUcwzmf9jw4tZdN57rEfAusRmWy6knHAF2a4rLGenJz5WPVuyggVzQ" +
+		"PHY6JjzKuw31B6e"
+	addressType, err := address.DecodeType(addr, network.Liquid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, address.ConfidentialP2Sh, addressType)
+}
+
+func TestDecodeAddressTypeP2wpkh(t *testing.T) {
+	addr := "ex1qlg343tpldc4wvjxn3jdq2qs35r8j5yd5vqrmu3"
+
+	addressType, err := address.DecodeType(addr, network.Liquid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, address.P2Wpkh, addressType)
+}
+
+func TestDecodeAddressTypeConfidentialP2wpkh(t *testing.T) {
+	addr := "lq1qqwrdmhm69vsq3qfym06tlyhfze9ltauay9tv4r34ueplfwtjx0q27dk2c4d3a" +
+		"9ms6wum04efclqph7dg4unwcmwmw4vnqreq3"
+	addressType, err := address.DecodeType(addr, network.Liquid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, address.ConfidentialP2Wpkh, addressType)
+}
+
+func TestDecodeAddressTypeP2wsh(t *testing.T) {
+	addr := "ert1q2z45rh444qmeand48lq0wp3jatxs2nzh492ds9s5yscv2pplxwesajz7q3"
+	addressType, err := address.DecodeType(addr, network.Regtest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, address.P2Wsh, addressType)
+}
+
+func TestDecodeAddressTypeConfidentialP2wsh(t *testing.T) {
+	addr := "lq1qq2akvug2el2rg6lt6aewh9rzy7dglf9ajdmrkknnwwl3jwxgfkh985x3lrzmr" +
+		"q2mc3c6aa85wgxxfm9v8r062qwq4ty579p54pn2q2hqnhgwv394ycf8"
+	addressType, err := address.DecodeType(addr, network.Liquid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, address.ConfidentialP2Wsh, addressType)
 }

--- a/example.go
+++ b/example.go
@@ -23,7 +23,7 @@ func main() {
 	_, publicKey := btcec.PrivKeyFromBytes(btcec.S256(), privateKeyBytes)
 
 	pay := payment.FromPublicKey(publicKey, &network.Regtest, nil)
-	legacyAddress := pay.PubKeyHash()
+	legacyAddress, _ := pay.PubKeyHash()
 	segwitAddress, _ := pay.WitnessPubKeyHash()
 	println(legacyAddress)
 	println(segwitAddress)

--- a/payment/examples_test.go
+++ b/payment/examples_test.go
@@ -3,6 +3,7 @@ package payment_test
 import (
 	"encoding/hex"
 	"fmt"
+
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/vulpemventures/go-elements/network"
 	"github.com/vulpemventures/go-elements/payment"
@@ -18,7 +19,8 @@ var privateKeyBytes, _ = hex.DecodeString(privateKeyHex)
 func ExampleFromPublicKey() {
 	_, publicKey := btcec.PrivKeyFromBytes(btcec.S256(), privateKeyBytes)
 	pay := payment.FromPublicKey(publicKey, &network.Regtest, nil)
-	fmt.Printf("P2PKH address %v\n:", pay.PubKeyHash())
+	addr, _ := pay.PubKeyHash()
+	fmt.Printf("P2PKH address %v\n:", addr)
 }
 
 //This examples shows how nested payment can be done in order to create non native SegWit(P2SH-P2WPKH) address

--- a/payment/payment.go
+++ b/payment/payment.go
@@ -4,13 +4,14 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"hash"
+
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcutil/base58"
 	"github.com/vulpemventures/go-elements/address"
 	"github.com/vulpemventures/go-elements/network"
 	"golang.org/x/crypto/ripemd160"
-	"hash"
 )
 
 // Payment defines the structure that holds the information different addresses
@@ -275,7 +276,7 @@ func (p *Payment) ConfidentialWitnessScriptHash() (string, error) {
 		p.Network.Blech32,
 		version,
 		p.BlindingKey.SerializeCompressed(),
-		p.Hash,
+		p.WitnessHash,
 	}
 	addr, err := address.ToBlech32(payload)
 	if err != nil {

--- a/payment/payment.go
+++ b/payment/payment.go
@@ -16,18 +16,15 @@ import (
 
 // Payment defines the structure that holds the information different addresses
 type Payment struct {
-	Network     *network.Network
-	PublicKey   *btcec.PublicKey
-	Hash        []byte
-	BlindingKey *btcec.PublicKey
-	Redeem      *Payment
-	Script      []byte
-	WitnessHash []byte
+	Hash          []byte
+	WitnessHash   []byte
+	Script        []byte
+	WitnessScript []byte
+	Redeem        *Payment
+	PublicKey     *btcec.PublicKey
+	BlindingKey   *btcec.PublicKey
+	Network       *network.Network
 }
-
-//target mail duty exit light void budget zone senior tag rude wisdom
-// priv 1cc080a4cd371eafcad489a29664af6a7276b362fe783443ce036552482b971d
-// pub 036f5646ed688b9279369da0a4ad78953ae7e6d300436ca8a3264360efe38236e3
 
 // FromPublicKey creates a Payment struct from a btcec.publicKey
 func FromPublicKey(
@@ -42,11 +39,19 @@ func FromPublicKey(
 		tmpNet = net
 	}
 	publicKeyBytes := pubkey.SerializeCompressed()
-	pkHash := hash160(publicKeyBytes)[:ripemd160.Size]
-	script := make([]byte, 0)
-	script = append([]byte{txscript.OP_0, byte(len(pkHash))}, pkHash...)
-	witnessHash := sha256.Sum256(script)
-	return &Payment{tmpNet, pubkey, pkHash, blindingKey, nil, script, witnessHash[:]}
+	pkHash := hash160(publicKeyBytes)
+	script := buildScript(pkHash, "p2pkh")
+	witnessScript := buildScript(pkHash, "p2wpkh")
+
+	return &Payment{
+		Hash:          pkHash,
+		WitnessHash:   pkHash,
+		Script:        script,
+		WitnessScript: witnessScript,
+		Network:       tmpNet,
+		PublicKey:     pubkey,
+		BlindingKey:   blindingKey,
+	}
 }
 
 // FromPublicKeys creates a multi-signature Payment struct from list of public key's
@@ -95,28 +100,32 @@ func FromPayment(payment *Payment) (*Payment, error) {
 	if payment.Script == nil || len(payment.Script) == 0 {
 		return nil, errors.New("payment's script can't be empty or nil")
 	}
-	redeem := &Payment{
-		payment.Network,
-		payment.PublicKey,
-		payment.Hash,
-		payment.BlindingKey,
-		payment.Redeem,
-		payment.Script,
-		payment.WitnessHash,
+
+	redeem := payment.copy()
+	scriptToHash := make([]byte, 0)
+	// the only case where the witnessScript is null is when wrapping multisig
+	if len(redeem.WitnessScript) > 0 {
+		scriptToHash = redeem.WitnessScript
+	} else {
+		scriptToHash = redeem.Script
 	}
-	witnessHash := sha256.Sum256(redeem.Script)
+	scriptHash := hash160(scriptToHash)
+	witnessScriptHash := sha256.Sum256(scriptToHash)
+	script := buildScript(scriptHash, "p2sh")
+	witnessScript := buildScript(witnessScriptHash[:], "p2wsh")
+
 	return &Payment{
-		payment.Network,
-		payment.PublicKey,
-		hash160(payment.Script),
-		payment.BlindingKey,
-		redeem,
-		payment.Script,
-		witnessHash[:],
+		Hash:          scriptHash,
+		WitnessHash:   witnessScriptHash[:],
+		Script:        script,
+		WitnessScript: witnessScript,
+		Redeem:        redeem,
+		Network:       redeem.Network,
+		BlindingKey:   redeem.BlindingKey,
 	}, nil
 }
 
-// FromPayment creates a nested Payment struct from script
+// FromScript creates parses a script into a Payment struct
 func FromScript(
 	script []byte,
 	net *network.Network,
@@ -125,6 +134,7 @@ func FromScript(
 	if script == nil || len(script) == 0 {
 		return nil, errors.New("payment's script can't be empty or nil")
 	}
+
 	var tmpNet *network.Network
 	if net == nil {
 		tmpNet = &network.Liquid
@@ -133,39 +143,60 @@ func FromScript(
 	}
 
 	scriptHash := make([]byte, 0)
-	if script[0] == txscript.OP_0 {
-		scriptHash = append(scriptHash, script[2:]...)
-	}
-	if script[0] == txscript.OP_HASH160 {
+	witnessScriptHash := make([]byte, 0)
+	_script := make([]byte, 0)
+	witnessScript := make([]byte, 0)
+	switch script[0] {
+	// p2wpkh / p2wsh
+	case txscript.OP_0:
+		// in case the script is a p2wpkh, we need to set also the legacy script
+		if len(script[2:]) == 20 {
+			scriptHash = append(scriptHash, script[2:]...)
+		}
+		witnessScriptHash = append(scriptHash, script[2:]...)
+		witnessScript = script
+	// p2sh
+	case txscript.OP_HASH160:
 		scriptHash = append(scriptHash, script[2:len(script)-1]...)
+		_script = script
+	// p2pkh
+	case txscript.OP_DUP:
+		scriptHash = append(scriptHash, script[3:len(script)-2]...)
+		_script = script
+	// multisig, here we do not calculate the hashes because this payment
+	// must be wrapped into another one
+	default:
+		_script = script
 	}
 
 	return &Payment{
-		Network:     tmpNet,
-		Hash:        scriptHash,
-		Script:      script,
-		BlindingKey: blindingKey,
+		Hash:          scriptHash,
+		WitnessHash:   witnessScriptHash,
+		Script:        _script,
+		WitnessScript: witnessScript,
+		Network:       tmpNet,
+		BlindingKey:   blindingKey,
 	}, nil
 }
 
 // PubKeyHash is a method of the Payment struct to derive a base58 p2pkh address
-func (p *Payment) PubKeyHash() string {
+func (p *Payment) PubKeyHash() (string, error) {
 	if p.Hash == nil || len(p.Hash) == 0 {
-		errors.New("payment's hash can't be empty or nil")
+		return "", errors.New("payment's hash can't be empty or nil")
 	}
 	payload := &address.Base58{p.Network.PubKeyHash, p.Hash}
 	addr := address.ToBase58(payload)
-	return addr
+	return addr, nil
 }
 
 // ConfidentialPubKeyHash is a method of the Payment struct to derive a
 //base58 confidential p2pkh address
-func (p *Payment) ConfidentialPubKeyHash() string {
+func (p *Payment) ConfidentialPubKeyHash() (string, error) {
 	if p.Hash == nil || len(p.Hash) == 0 {
-		errors.New("payment's hash can't be empty or nil")
+		return "", errors.New("payment's hash can't be empty or nil")
 	}
 	if p.BlindingKey == nil {
-		errors.New("payment's blinding key can't be nil")
+		return "", errors.New("payment's blinding key can't be nil")
 	}
 
 	prefix := [1]byte{p.Network.PubKeyHash}
@@ -176,7 +207,7 @@ func (p *Payment) ConfidentialPubKeyHash() string {
 		),
 		p.Hash...,
 	)
-	return base58.CheckEncode(confidentialAddress, p.Network.Confidential)
+	return base58.CheckEncode(confidentialAddress, p.Network.Confidential), nil
 }
 
 // ScriptHash is a method of the Payment struct to derive a base58 p2sh address
@@ -191,12 +222,12 @@ func (p *Payment) ScriptHash() (string, error) {
 
 // ConfidentialScriptHash is a method of the Payment struct to derive a
 //base58 confidential p2sh address
-func (p *Payment) ConfidentialScriptHash() string {
+func (p *Payment) ConfidentialScriptHash() (string, error) {
 	if p.Hash == nil || len(p.Hash) == 0 {
-		errors.New("payment's hash can't be empty or nil")
+		return "", errors.New("payment's hash can't be empty or nil")
 	}
 	if p.BlindingKey == nil {
-		errors.New("payment's blinding key can't be nil")
+		return "", errors.New("payment's blinding key can't be nil")
 	}
 
 	prefix := [1]byte{p.Network.ScriptHash}
@@ -207,17 +238,17 @@ func (p *Payment) ConfidentialScriptHash() string {
 		),
 		p.Hash...,
 	)
-	return base58.CheckEncode(confidentialAddress, p.Network.Confidential)
+	return base58.CheckEncode(confidentialAddress, p.Network.Confidential), nil
 }
 
 // WitnessPubKeyHash is a method of the Payment struct to derive a base58 p2wpkh address
 func (p *Payment) WitnessPubKeyHash() (string, error) {
-	if p.Hash == nil || len(p.Hash) == 0 {
+	if p.WitnessHash == nil || len(p.WitnessHash) == 0 {
 		return "", errors.New("payment's hash can't be empty or nil")
 	}
 	//Here the Version for wpkh is always 0
 	version := byte(0x00)
-	payload := &address.Bech32{p.Network.Bech32, version, p.Hash}
+	payload := &address.Bech32{p.Network.Bech32, version, p.WitnessHash}
 	addr, err := address.ToBech32(payload)
 	if err != nil {
 		return "", nil
@@ -228,46 +259,7 @@ func (p *Payment) WitnessPubKeyHash() (string, error) {
 // ConfidentialWitnessPubKeyHash is a method of the Payment struct to derive
 //a confidential blech32 p2wpkh address
 func (p *Payment) ConfidentialWitnessPubKeyHash() (string, error) {
-	if p.Hash == nil || len(p.Hash) == 0 {
-		return "", errors.New("payment's hash can't be empty or nil")
-	}
-	//Here the Version for wpkh is always 0
-	version := byte(0x00)
-	payload := &address.Blech32{
-		p.Network.Blech32,
-		version,
-		p.BlindingKey.SerializeCompressed(),
-		p.Hash,
-	}
-	addr, err := address.ToBlech32(payload)
-	if err != nil {
-		return "", nil
-	}
-	return addr, nil
-}
-
-// WitnessScriptHash is a method of the Payment struct to derive a base58 p2wsh address
-func (p *Payment) WitnessScriptHash() (string, error) {
-	if p.Script == nil || len(p.Script) == 0 {
-		return "", errors.New("payment's script can't be empty or nil")
-	}
 	if p.WitnessHash == nil || len(p.WitnessHash) == 0 {
-		return "", errors.New("payment's witnessHash can't be empty or nil")
-	}
-
-	version := byte(0x00)
-	payload := &address.Bech32{p.Network.Bech32, version, p.WitnessHash}
-	addr, err := address.ToBech32(payload)
-	if err != nil {
-		return "", err
-	}
-	return addr, nil
-}
-
-// ConfidentialWitnessScriptHash is a method of the Payment struct to derive
-//a confidential blech32 p2wsh address
-func (p *Payment) ConfidentialWitnessScriptHash() (string, error) {
-	if p.Hash == nil || len(p.Hash) == 0 {
 		return "", errors.New("payment's hash can't be empty or nil")
 	}
 	//Here the Version for wpkh is always 0
@@ -285,6 +277,70 @@ func (p *Payment) ConfidentialWitnessScriptHash() (string, error) {
 	return addr, nil
 }
 
+// WitnessScriptHash is a method of the Payment struct to derive a base58 p2wsh address
+func (p *Payment) WitnessScriptHash() (string, error) {
+	if p.WitnessHash == nil || len(p.WitnessHash) == 0 {
+		return "", errors.New("payment's witnessHash can't be empty or nil")
+	}
+
+	version := byte(0x00)
+	payload := &address.Bech32{p.Network.Bech32, version, p.WitnessHash}
+	addr, err := address.ToBech32(payload)
+	if err != nil {
+		return "", err
+	}
+	return addr, nil
+}
+
+// ConfidentialWitnessScriptHash is a method of the Payment struct to derive
+//a confidential blech32 p2wsh address
+func (p *Payment) ConfidentialWitnessScriptHash() (string, error) {
+	if p.WitnessHash == nil || len(p.WitnessHash) == 0 {
+		return "", errors.New("payment's hash can't be empty or nil")
+	}
+	//Here the Version for wpkh is always 0
+	version := byte(0x00)
+	payload := &address.Blech32{
+		p.Network.Blech32,
+		version,
+		p.BlindingKey.SerializeCompressed(),
+		p.WitnessHash,
+	}
+	addr, err := address.ToBlech32(payload)
+	if err != nil {
+		return "", nil
+	}
+	return addr, nil
+}
+
+func (p *Payment) copy() *Payment {
+	var redeem *Payment
+	var pubkey *btcec.PublicKey
+	var blindkey *btcec.PublicKey
+	if p.Redeem != nil {
+		redeem = &Payment{}
+		*redeem = *p.Redeem
+	}
+	if p.PublicKey != nil {
+		pubkey = &btcec.PublicKey{}
+		*pubkey = *p.PublicKey
+	}
+	if p.BlindingKey != nil {
+		blindkey = &btcec.PublicKey{}
+		*blindkey = *p.BlindingKey
+	}
+	return &Payment{
+		Hash:          p.Hash,
+		WitnessHash:   p.WitnessHash,
+		Script:        p.Script,
+		WitnessScript: p.WitnessScript,
+		Redeem:        redeem,
+		PublicKey:     pubkey,
+		BlindingKey:   blindkey,
+		Network:       p.Network,
+	}
+}
+
 // Calculate the hash of hasher over buf.
 func calcHash(buf []byte, hasher hash.Hash) []byte {
 	hasher.Write(buf)
@@ -294,4 +350,23 @@ func calcHash(buf []byte, hasher hash.Hash) []byte {
 // Hash160 calculates the hash ripemd160(sha256(b)).
 func hash160(buf []byte) []byte {
 	return calcHash(calcHash(buf, sha256.New()), ripemd160.New())
+}
+
+// buildScript returns the requested scriptType script with the provided hash
+func buildScript(hash []byte, scriptType string) []byte {
+	builder := txscript.NewScriptBuilder()
+
+	switch scriptType {
+	case "p2pkh":
+		builder.AddOp(txscript.OP_DUP).AddOp(txscript.OP_HASH160)
+		builder.AddData(hash)
+		builder.AddOp(txscript.OP_EQUALVERIFY).AddOp(txscript.OP_CHECKSIG)
+	case "p2sh":
+		builder.AddOp(txscript.OP_HASH160).AddData(hash).AddOp(txscript.OP_EQUAL)
+	case "p2wpkh", "p2wsh":
+		builder.AddOp(txscript.OP_0).AddData(hash)
+	}
+
+	script, _ := builder.Script()
+	return script
 }

--- a/payment/payment_test.go
+++ b/payment/payment_test.go
@@ -2,12 +2,12 @@ package payment_test
 
 import (
 	"encoding/hex"
+	"testing"
+
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/stretchr/testify/assert"
-	"github.com/vulpemventures/go-elements/address"
 	"github.com/vulpemventures/go-elements/network"
 	"github.com/vulpemventures/go-elements/payment"
-	"testing"
 )
 
 const (
@@ -18,42 +18,47 @@ const (
 var privateKeyBytes1, _ = hex.DecodeString(privKeyHex1)
 var privateKeyBytes2, _ = hex.DecodeString(privKeyHex2)
 
-func TestLegacyAddress(t *testing.T) {
+func TestLegacyPubkeyHash(t *testing.T) {
 	_, publicKey := btcec.PrivKeyFromBytes(btcec.S256(), privateKeyBytes1)
 
 	pay := payment.FromPublicKey(publicKey, &network.Regtest, nil)
-	if pay.PubKeyHash() != "2dxEMfPLNa6rZRAfPe7wNWoaUptyBzQ2Zva" {
-		t.Errorf("TestLegacyAddress: error when encoding legacy")
+	addr, err := pay.PubKeyHash()
+	if err != nil {
+		t.Fatal(err)
 	}
+	expected := "2dxEMfPLNa6rZRAfPe7wNWoaUptyBzQ2Zva"
+	assert.Equal(t, expected, addr)
 }
 
-func TestSegwitAddress(t *testing.T) {
+func TestSegwitPubkeyHash(t *testing.T) {
 	_, publicKey := btcec.PrivKeyFromBytes(btcec.S256(), privateKeyBytes1)
 
 	pay := payment.FromPublicKey(publicKey, &network.Regtest, nil)
-	p2pkh, err := pay.WitnessPubKeyHash()
+	addr, err := pay.WitnessPubKeyHash()
 	if err != nil {
 		t.Error(err)
 	}
-	if p2pkh != "ert1qlg343tpldc4wvjxn3jdq2qs35r8j5yd5kjfrrt" {
-		t.Errorf("TestSegwitAddress: error when encoding segwit")
-	}
+	expected := "ert1qlg343tpldc4wvjxn3jdq2qs35r8j5yd5kjfrrt"
+	assert.Equal(t, expected, addr)
 }
 
-func TestScriptHash(t *testing.T) {
+func TestLegacyScriptHash(t *testing.T) {
 	_, publicKey := btcec.PrivKeyFromBytes(btcec.S256(), privateKeyBytes1)
 	p2wpkh := payment.FromPublicKey(publicKey, &network.Regtest, nil)
-	pay, err := payment.FromPayment(p2wpkh)
-	p2sh, err := pay.ScriptHash()
+
+	p2sh, err := payment.FromPayment(p2wpkh)
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr, err := p2sh.ScriptHash()
 	if err != nil {
 		t.Error(err)
 	}
-	if p2sh != "XZavBojABpfXhPWkw7y9YYFNAezUHZR47m" {
-		t.Errorf("TestScriptHash: error when encoding script hash")
-	}
+	expectedAddr := "XZavBojABpfXhPWkw7y9YYFNAezUHZR47m"
+	assert.Equal(t, expectedAddr, addr)
 }
 
-func TestP2WSH(t *testing.T) {
+func TestSegwitScriptHash(t *testing.T) {
 	redeemScript := "52410479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959" +
 		"f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d0" +
 		"8ffb10d4b84104c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09" +
@@ -88,13 +93,13 @@ func TestP2WSH(t *testing.T) {
 	}
 }
 
-func TestFromPublicKeys(t *testing.T) {
+func TestMultisig(t *testing.T) {
 	_, publicKey1 := btcec.PrivKeyFromBytes(btcec.S256(), privateKeyBytes1)
 	_, publicKey2 := btcec.PrivKeyFromBytes(btcec.S256(), privateKeyBytes2)
 
 	p2ms, err := payment.FromPublicKeys(
 		[]*btcec.PublicKey{publicKey1, publicKey2},
-		1,
+		2,
 		&network.Regtest,
 		nil,
 	)
@@ -102,372 +107,112 @@ func TestFromPublicKeys(t *testing.T) {
 		t.Error(err)
 	}
 
-	if hex.EncodeToString(p2ms.Script) != "5121036f5646ed688b9279369da0a4ad78"+
-		"953ae7e6d300436ca8a3264360efe38236e321023c61f59e9a3a3eb01c3ed0cf967a"+
-		"d217153944bcf2498a8fd6e70b27c7ab6ee652ae" {
-		t.Error("hex value of p2ms script not as expected")
-	}
+	expectedRedeemScript := "5221036f5646ed688b9279369da0a4ad78953ae7e6d300436" +
+		"ca8a3264360efe38236e321023c61f59e9a3a3eb01c3ed0cf967ad217153944bcf2498a" +
+		"8fd6e70b27c7ab6ee652ae"
+	assert.Equal(t, expectedRedeemScript, hex.EncodeToString(p2ms.Redeem.Script))
 
-	p2wsh, err := payment.FromPayment(p2ms)
+	p2wshAddr, err := p2ms.WitnessScriptHash()
 	if err != nil {
 		t.Error(err)
 	}
+	expectedAddr :=
+		"ert1q3pa0pn2zef7eh2wuj4nqzas3xfzap79dful920kv6fuey592ujvs274fsu"
+	assert.Equal(t, expectedAddr, p2wshAddr)
 
-	p2wshAddress, err := p2wsh.WitnessScriptHash()
+	p2shAddr, err := p2ms.ScriptHash()
 	if err != nil {
 		t.Error(err)
 	}
-	if p2wshAddress != "ert1q484pt3gqgthcxa35nl4t6utpd0uf7tkm240hlxe6k4newky"+
-		"dwcqs5sjc4c" {
-		t.Errorf("TestSegwitAddress: error when encoding segwit")
-	}
-
-	pay, err := payment.FromPayment(p2ms)
-	p2sh, err := pay.ScriptHash()
-	if err != nil {
-		t.Error(err)
-	}
-	if p2sh != "XJkohBHRMT8JUknSqCH7aJP9gAuAe9eNLY" {
-		t.Errorf("TestScriptHash: error when encoding script hash")
-	}
+	expectedAddr = "XLggw3oXkn4QwAkNt5uG8EBKTuGf69BJJG"
+	assert.Equal(t, expectedAddr, p2shAddr)
 }
 
-func TestPaymentConfidentialPubKeyHash(t *testing.T) {
-	expected := "VTpzxkqVGbraaCz18fQ2GxLvZkupCi2MPtUdt9ygAEeZ8v9gZPtkD5RUc" +
-		"ap55WZ3aVsbUG6TsQvXc8R3"
-	pk1 := "030000000000000000000000000000000000000000000000000000000000000001"
-	pk1Byte, err := hex.DecodeString(pk1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	pubKey1, err := btcec.ParsePubKey(pk1Byte, btcec.S256())
+func TestLegacyPubKeyHashConfidential(t *testing.T) {
+	pubkeyBytes, _ := hex.DecodeString(
+		"030000000000000000000000000000000000000000000000000000000000000001",
+	)
+	pubkey, err := btcec.ParsePubKey(pubkeyBytes, btcec.S256())
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	pk2 := "030000000000000000000000000000000000000000000000000000000000000001"
-	pk2Byte, err := hex.DecodeString(pk2)
+	pay := payment.FromPublicKey(pubkey, &network.Liquid, pubkey)
+	address, err := pay.ConfidentialPubKeyHash()
 	if err != nil {
 		t.Fatal(err)
 	}
-	pubKey2, err := btcec.ParsePubKey(pk2Byte, btcec.S256())
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	payment := payment.FromPublicKey(pubKey1, &network.Liquid, pubKey2)
-	assert.Equal(t, expected, payment.ConfidentialPubKeyHash())
-}
-
-func TestPaymentConfidentialScriptHash(t *testing.T) {
-	expected := "VJLCUu2hpcjPaTGMnANXni8wVYjsCAiTEznE5zgRZZyAWXE2P6rz6Dvph" +
-		"BHSn7iz4w9sLb3mFSHGJbte"
-	script, err := hex.DecodeString(
-		"a9149f840a5fc02407ef0ad499c2ec0eb0b942fb008687")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	pk1 := "030000000000000000000000000000000000000000000000000000000000000001"
-	pk2Byte, err := hex.DecodeString(pk1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	blindingKey, err := btcec.ParsePubKey(pk2Byte, btcec.S256())
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	payment, err := payment.FromScript(script, &network.Liquid, blindingKey)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Equal(t, expected, payment.ConfidentialScriptHash())
-
-}
-
-func TestPaymentConfidentialWitnessPubKeyHash(t *testing.T) {
-	expected := "lq1qqvqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqz95" +
-		"tny4ul3zq2qcskw55h5rhzymdpv5dzw6hr8jz3tq5y"
-	pk1 := "030000000000000000000000000000000000000000000000000000000000000001"
-	pk1Byte, err := hex.DecodeString(pk1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	pubKey1, err := btcec.ParsePubKey(pk1Byte, btcec.S256())
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	pk2 := "030000000000000000000000000000000000000000000000000000000000000001"
-	pk2Byte, err := hex.DecodeString(pk2)
-	if err != nil {
-		t.Fatal(err)
-	}
-	pubKey2, err := btcec.ParsePubKey(pk2Byte, btcec.S256())
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	payment := payment.FromPublicKey(pubKey1, &network.Liquid, pubKey2)
-	address, err := payment.ConfidentialWitnessPubKeyHash()
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	expected := "VTpzxkqVGbraaCz18fQ2GxLvZkupCi2MPtUdt9ygAEeZ8v9gZPtkD5RUcap55" +
+		"WZ3aVsbUG6TsQvXc8R3"
 	assert.Equal(t, expected, address)
 }
 
-func TestConfidentialWitnessScriptHash(t *testing.T) {
-	expected := "lq1qqvqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq" +
-		"r5x3lrzmrq2mc3c6aa85wgxxfm9v8r062qwq4ty579p54pn2q2hq6f9r3gz0h4tn"
-
-	script, err := hex.DecodeString("0014d0d1f8c5b1815bc471aef4f4720c64eca" +
-		"c38dfa501c0aac94f1434a866a02ae0")
+func TestLegacyScriptHashConfidential(t *testing.T) {
+	script, _ := hex.DecodeString(
+		"a9149f840a5fc02407ef0ad499c2ec0eb0b942fb008687",
+	)
+	pubkeyBytes, _ := hex.DecodeString(
+		"030000000000000000000000000000000000000000000000000000000000000001",
+	)
+	blindingKey, err := btcec.ParsePubKey(pubkeyBytes, btcec.S256())
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	pk1 := "030000000000000000000000000000000000000000000000000000000000000001"
-	pk2Byte, err := hex.DecodeString(pk1)
+	pay, err := payment.FromScript(script, &network.Liquid, blindingKey)
 	if err != nil {
 		t.Fatal(err)
 	}
-	blindingKey, err := btcec.ParsePubKey(pk2Byte, btcec.S256())
+	addr, err := pay.ConfidentialScriptHash()
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	p, err := payment.FromScript(script, &network.Liquid, blindingKey)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	addr, err := p.ConfidentialWitnessScriptHash()
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	expected := "VJLCUu2hpcjPaTGMnANXni8wVYjsCAiTEznE5zgRZZyAWXE2P6rz6DvphBHSn" +
+		"7iz4w9sLb3mFSHGJbte"
 	assert.Equal(t, expected, addr)
 }
 
-func TestDecodeAddressTypeP2Pkh(t *testing.T) {
-	privKey1, err := btcec.NewPrivateKey(btcec.S256())
+func TestSegwitPubKeyHashConfidential(t *testing.T) {
+	pubkeyBytes, _ := hex.DecodeString("030000000000000000000000000000000000000000000000000000000000000001")
+	pubkey, err := btcec.ParsePubKey(pubkeyBytes, btcec.S256())
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	pay := payment.FromPublicKey(
-		privKey1.PubKey(),
-		&network.Liquid,
-		nil,
-	)
-	p2pkhAddress := pay.PubKeyHash()
-
-	addressType, err := address.DecodeType(
-		p2pkhAddress,
-		network.Liquid,
-	)
+	pay := payment.FromPublicKey(pubkey, &network.Liquid, pubkey)
+	address, err := pay.ConfidentialWitnessPubKeyHash()
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, address.P2Pkh, addressType)
+
+	expected := "lq1qqvqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqz95tn" +
+		"y4ul3zq2qcskw55h5rhzymdpv5dzw6hr8jz3tq5y"
+	assert.Equal(t, expected, address)
 }
 
-func TestDecodeAddressTypeP2sh(t *testing.T) {
-	_, publicKey := btcec.PrivKeyFromBytes(btcec.S256(), privateKeyBytes1)
-	p2wpkh := payment.FromPublicKey(publicKey, &network.Liquid, nil)
-	pay, err := payment.FromPayment(p2wpkh)
-	p2shAddress, err := pay.ScriptHash()
-	if err != nil {
-		t.Error(err)
-	}
-
-	addressType, err := address.DecodeType(
-		p2shAddress,
-		network.Liquid,
+func TestSegwitScriptHashConfidential(t *testing.T) {
+	script, _ := hex.DecodeString(
+		"0014d0d1f8c5b1815bc471aef4f4720c64ecac38dfa501c0aac94f1434a866a02ae0",
 	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	assert.Equal(t, address.P2Sh, addressType)
-}
-
-func TestDecodeAddressTypeConfidentialP2Pkh(t *testing.T) {
-	privKey, err := btcec.NewPrivateKey(btcec.S256())
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	blindingPrivKey, err := btcec.NewPrivateKey(btcec.S256())
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	pay := payment.FromPublicKey(
-		privKey.PubKey(),
-		&network.Liquid,
-		blindingPrivKey.PubKey(),
+	pubkeyBytes, _ := hex.DecodeString(
+		"030000000000000000000000000000000000000000000000000000000000000001",
 	)
-	confidentialP2pkhAddress := pay.ConfidentialPubKeyHash()
-
-	addressType, err := address.DecodeType(
-		confidentialP2pkhAddress,
-		network.Liquid,
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	assert.Equal(t, address.ConfidentialP2Pkh, addressType)
-}
-
-func TestDecodeAddressTypeConfidentialP2sh(t *testing.T) {
-	privKey1, err := btcec.NewPrivateKey(btcec.S256())
+	blindingKey, err := btcec.ParsePubKey(pubkeyBytes, btcec.S256())
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	privKey2, err := btcec.NewPrivateKey(btcec.S256())
+	pay, err := payment.FromScript(script, &network.Liquid, blindingKey)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	pay := payment.FromPublicKey(
-		privKey1.PubKey(),
-		&network.Liquid,
-		privKey2.PubKey(),
-	)
-	confidentialP2shAddress := pay.ConfidentialScriptHash()
-
-	addressType, err := address.DecodeType(
-		confidentialP2shAddress,
-		network.Liquid,
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	assert.Equal(t, address.ConfidentialP2Sh, addressType)
-}
-
-func TestDecodeAddressTypeP2wpkh(t *testing.T) {
-	_, publicKey := btcec.PrivKeyFromBytes(btcec.S256(), privateKeyBytes1)
-
-	pay := payment.FromPublicKey(publicKey, &network.Liquid, nil)
-	p2wpkhAddress, err := pay.WitnessPubKeyHash()
-	if err != nil {
-		t.Error(err)
-	}
-
-	addressType, err := address.DecodeType(
-		p2wpkhAddress,
-		network.Liquid,
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	assert.Equal(t, address.P2Wpkh, addressType)
-}
-
-func TestDecodeAddressTypeConfidentialP2wpkh(t *testing.T) {
-	privKey1, err := btcec.NewPrivateKey(btcec.S256())
+	addr, err := pay.ConfidentialWitnessScriptHash()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	privKey2, err := btcec.NewPrivateKey(btcec.S256())
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	pay := payment.FromPublicKey(
-		privKey1.PubKey(),
-		&network.Liquid,
-		privKey2.PubKey(),
-	)
-	confidentialP2wpkh, err := pay.ConfidentialWitnessPubKeyHash()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	addressType, err := address.DecodeType(
-		confidentialP2wpkh,
-		network.Liquid,
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	assert.Equal(t, address.ConfidentialP2Wpkh, addressType)
-}
-
-func TestDecodeAddressTypeP2wsh(t *testing.T) {
-	redeemScript := "52410479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f" +
-		"2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08f" +
-		"fb10d4b84104c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95" +
-		"c709ee51ae168fea63dc339a3c58419466ceaeef7f632653266d0e1236431a950cfe5" +
-		"2a52ae"
-	redeemScriptBytes, err := hex.DecodeString(redeemScript)
-	if err != nil {
-		t.Error(err)
-	}
-
-	p2ms, err := payment.FromScript(
-		redeemScriptBytes,
-		&network.Regtest,
-		nil,
-	)
-	if err != nil {
-		t.Error(err)
-	}
-
-	p2wsh, err := payment.FromPayment(p2ms)
-	if err != nil {
-		t.Error(err)
-	}
-
-	p2wshAddress, err := p2wsh.WitnessScriptHash()
-	if err != nil {
-		t.Error(err)
-	}
-
-	addressType, err := address.DecodeType(
-		p2wshAddress,
-		network.Regtest,
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	assert.Equal(t, address.P2Wsh, addressType)
-}
-
-func TestDecodeAddressTypeConfidentialP2wsh(t *testing.T) {
-	script, err := hex.DecodeString("0014d0d1f8c5b1815bc471aef4" +
-		"f4720c64ecac38dfa501c0aac94f1434a866a02ae0")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	privKey, err := btcec.NewPrivateKey(btcec.S256())
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	pay, err := payment.FromScript(script, &network.Liquid, privKey.PubKey())
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	confidentialP2Wsh, err := pay.ConfidentialWitnessScriptHash()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	addressType, err := address.DecodeType(
-		confidentialP2Wsh,
-		network.Liquid,
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	assert.Equal(t, address.ConfidentialP2Wsh, addressType)
+	expected := "lq1qqvqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqr5x3l" +
+		"rzmrq2mc3c6aa85wgxxfm9v8r062qwq4ty579p54pn2q2hq6f9r3gz0h4tn"
+	assert.Equal(t, expected, addr)
 }

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -562,7 +562,7 @@ func (tx *Transaction) HashForSignature(
 	if err != nil {
 		return [32]byte{}, err
 	}
-	buf = append(buf, []byte{0x00, 0x00, 0x00, byte(hashType)}...)
+	buf = append(buf, []byte{byte(hashType), 0x00, 0x00, 0x00}...)
 	return chainhash.DoubleHashH(buf), nil
 }
 


### PR DESCRIPTION
This fixes the bug in the serialization of the transaction for producing a signature by reversing the bytes of the sighash appended to the serialized transaction.

This also fixes the payment package in order to make it more useful than it actually is.
A new field `WitnessScript` is added to the `Payment` struct so that the user can retrieve both the legacy and the witness script when necessary (you can see from the pset tests ([here](https://github.com/vulpemventures/go-elements/blob/master/pset/pset_test.go#L164) for example) that at the moment we have to manually create a legacy script for a p2wpkh input).
According to the addition of this field, the existing factory methods have been updated/fixed.

Last but not least, the tests of the pset package that use the payment one have been updated, resulting in smoother code.

This closes #116.
This closes #115.
This closes #114.

Please @tiero review this.
