### PR TITLE
Fix sanity test and ordering in checkIsMultiSigScript

### DIFF
--- a/pset/utils.go
+++ b/pset/utils.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
-	"github.com/vulpemventures/go-elements/internal/bufferutil"
 	"io"
 	"sort"
 
@@ -28,6 +27,7 @@ import (
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil/psbt"
+	"github.com/vulpemventures/go-elements/internal/bufferutil"
 	"github.com/vulpemventures/go-elements/transaction"
 )
 
@@ -72,14 +72,14 @@ func checkIsMultiSigScript(pubKeys [][]byte, sigs [][]byte,
 
 	// Inspect the script to ensure that the number of sigs and pubkeys is
 	// correct
-	numSigs, numPubKeys, err := txscript.CalcMultiSigStats(script)
+	_, numSigs, err := txscript.CalcMultiSigStats(script)
 	if err != nil {
 		return false
 	}
 
 	// If the number of sigs provided, doesn't match the number of required
 	// pubkeys, then we can't proceed as we're not yet final.
-	if numPubKeys != len(pubKeys) || numSigs != len(sigs) {
+	if numSigs != len(pubKeys) || numSigs != len(sigs) {
 		return false
 	}
 


### PR DESCRIPTION
This adds the same fixes of btcutil's [psbt/utils.go](https://github.com/btcsuite/btcutil/pull/154/files) to our pset/utils.go `checkIsMultiSigScript`.