### PR TITLE
From confidential

### DIFF
--- a/address/address.go
+++ b/address/address.go
@@ -4,13 +4,14 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"strings"
+
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcutil/base58"
 	"github.com/btcsuite/btcutil/bech32"
 	"github.com/vulpemventures/go-elements/blech32"
 	"github.com/vulpemventures/go-elements/network"
 	"golang.org/x/crypto/ripemd160"
-	"strings"
 )
 
 // Address defines the address as string
@@ -35,10 +36,18 @@ const (
 	P2WshScript      = 5
 )
 
-// Base58 type defines the structure of an address legacy or wrapped segwit
+// Base58 type defines the structure of a legacy or wrapped segwit address
 type Base58 struct {
 	Version byte
 	Data    []byte
+}
+
+// Base58Confidential type defines the structure of a legacy or wrapped segwit
+// confidential address
+type Base58Confidential struct {
+	Base58
+	Version   byte
+	PublicKey []byte
 }
 
 // Bech32 defines the structure of an address native segwit
@@ -54,6 +63,12 @@ type Blech32 struct {
 	Version   byte
 	PublicKey []byte
 	Program   []byte
+}
+
+// ConfidentialAddress defines the structure of a generic confidential address
+type ConfidentialAddress struct {
+	Address     string
+	BlindingKey []byte
 }
 
 // FromBase58 decodes a string that was base58 encoded and verifies the checksum.
@@ -154,6 +169,43 @@ func ToBech32(bc *Bech32) (string, error) {
 	return bech, nil
 }
 
+// FromBase58Confidential decodes a confidenail address that was base58 encoded
+//  and verifies the checksum.
+func FromBase58Confidential(address string) (*Base58Confidential, error) {
+	decoded, version, err := base58.CheckDecode(address)
+	if err != nil {
+		return nil, errors.New("Invalid address")
+	}
+
+	if len(decoded) < 54 {
+		return nil, errors.New(address + " is too short")
+	}
+	if len(decoded) > 54 {
+		return nil, errors.New(address + " is too long")
+	}
+
+	// Blinded decoded address has the form:
+	// BLIND_PREFIX | ADDRESS_PREFIX | BLINDING_KEY | SCRIPT_HASH
+	// Prefixes are 1 byte long, thus blinding key always starts at 3rd byte
+
+	return &Base58Confidential{
+		Base58{
+			decoded[0],
+			decoded[34:],
+		},
+		version,
+		decoded[1:34],
+	}, nil
+}
+
+// ToBase58Confidential prepends a version byte and appends a four byte checksum.
+func ToBase58Confidential(b *Base58Confidential) string {
+	data := append([]byte{b.Base58.Version}, b.PublicKey...)
+	data = append(data, b.Base58.Data...)
+	encoded := base58.CheckEncode(data, b.Version)
+	return encoded
+}
+
 // FromBlech32 decodes a blech32 encoded string, returning the human-readable
 // part and the data part excluding the checksum.
 func FromBlech32(address string) (*Blech32, error) {
@@ -250,6 +302,114 @@ func ToBlech32(bl *Blech32) (string, error) {
 	}
 
 	return blech32Addr, nil
+}
+
+// FromConfidential returns the unconfidential address and the blinding public
+// key that form the confidential address
+func FromConfidential(address string) (*ConfidentialAddress, error) {
+	net, err := NetworkForAddress(address)
+	if err != nil {
+		return nil, err
+	}
+
+	addressType, err := DecodeType(address, *net)
+	if err != nil {
+		return nil, err
+	}
+
+	switch addressType {
+	case ConfidentialP2Pkh, ConfidentialP2Sh:
+		fromBase58, err := FromBase58Confidential(address)
+		if err != nil {
+			return nil, err
+		}
+
+		addr := ToBase58(&fromBase58.Base58)
+
+		return &ConfidentialAddress{
+			Address:     addr,
+			BlindingKey: fromBase58.PublicKey,
+		}, nil
+	case ConfidentialP2Wpkh, ConfidentialP2Wsh:
+		fromBlech32, err := FromBlech32(address)
+		if err != nil {
+			return nil, err
+		}
+
+		addr, err := ToBech32(&Bech32{
+			Prefix:  net.Bech32,
+			Version: fromBlech32.Version,
+			Program: fromBlech32.Program,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		return &ConfidentialAddress{
+			Address:     addr,
+			BlindingKey: fromBlech32.PublicKey,
+		}, nil
+	default:
+		return nil, errors.New("unknown address type")
+	}
+}
+
+// ToConfidential returns the confidential address formed by the given
+// unconfidential address and blinding public key
+func ToConfidential(ca *ConfidentialAddress) (string, error) {
+	net, err := NetworkForAddress(ca.Address)
+	if err != nil {
+		return "", err
+	}
+
+	if strings.HasPrefix(ca.Address, net.Bech32) {
+		b32, _ := FromBech32(ca.Address)
+		return ToBlech32(&Blech32{
+			Prefix:    net.Blech32,
+			Version:   b32.Version,
+			Program:   b32.Program,
+			PublicKey: ca.BlindingKey,
+		})
+	}
+
+	b58, _ := FromBase58(ca.Address)
+	return ToBase58Confidential(&Base58Confidential{
+		*b58,
+		net.Confidential,
+		ca.BlindingKey,
+	}), nil
+}
+
+// NetworkForAddress returns the network based on the prefix of the given address
+func NetworkForAddress(address string) (*network.Network, error) {
+	if strings.HasPrefix(address, network.Liquid.Bech32) ||
+		strings.HasPrefix(address, network.Liquid.Blech32) {
+		return &network.Liquid, nil
+	}
+
+	if strings.HasPrefix(address, network.Regtest.Bech32) ||
+		strings.HasPrefix(address, network.Regtest.Blech32) {
+		return &network.Regtest, nil
+	}
+
+	_, prefix, err := base58.CheckDecode(address)
+	if err != nil {
+		return nil, err
+	}
+
+	if prefix == network.Liquid.Confidential ||
+		prefix == network.Liquid.PubKeyHash ||
+		prefix == network.Liquid.ScriptHash {
+		return &network.Liquid, nil
+	}
+
+	if prefix == network.Regtest.Confidential ||
+		prefix == network.Regtest.PubKeyHash ||
+		prefix == network.Regtest.ScriptHash {
+		return &network.Regtest, nil
+	}
+
+	return nil, errors.New("unknown prefix for address")
 }
 
 //ToOutputScript creates a new script to pay a transaction output to a the

--- a/address/address_test.go
+++ b/address/address_test.go
@@ -1,239 +1,162 @@
-package address_test
+package address
 
 import (
 	"encoding/hex"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/vulpemventures/go-elements/address"
 	"github.com/vulpemventures/go-elements/network"
 )
 
-const (
-	base58address = "XFKcLWJmPuToz62uc2sgCBUddmH6yopoxE"
-	base58hexdata = "2b919bfc040faed8de5469dfa0241a3c1e5681be"
-	bech32address = "ert1qlg343tpldc4wvjxn3jdq2qs35r8j5yd5kjfrrt"
-	addr1         = "el1qqw3e3mk4ng3ks43mh54udznuekaadh9lgwef3mwgzrfzakmdwcvqpe4ppdaa3t44v3zv2u6w56pv6tc666fvgzaclqjnkz0sd"
-	addr2         = "el1qqw3e3mk4ng3ks43mh54udznuekaadh9lgwef3mwgzrfzakmdwcvqqve2xzutyaf7vjcap67f28q90uxec2ve95g3rpu5crapcmfr2l9xl5jzazvcpysz"
-	pubKey        = "03a398eed59a2368563bbd2bc68a7ccdbbd6dcbf43b298edc810d22edb6d761800"
-	witProg1      = "e6a10b7bd8aeb56444c5734ea682cd2f1ad692c4"
-	witProg2      = "332a30b8b2753e64b1d0ebc951c057f0d9c29992d11118794c0fa1c6d2357ca6"
-)
-
-func TestFromBase58(t *testing.T) {
-	base58, err := address.FromBase58(base58address)
-	if err != nil {
-		t.Errorf("TestFromBase58: base58 decoding error")
+func TestBase58(t *testing.T) {
+	addresses := []string{
+		"XFKcLWJmPuToz62uc2sgCBUddmH6yopoxE",
+		"2dnTicaj6kay4FAV1N9qNDNawYehaxpifkP",
 	}
 
-	if base58.Version != 75 {
-		t.Errorf("TestFromBase58: wrong version")
-	}
-
-	if len(base58.Data) != 20 {
-		t.Errorf("TestFromBase58: data size mismatch")
-	}
-}
-
-func TestToBase58(t *testing.T) {
-	data, _ := hex.DecodeString(base58hexdata)
-	payload := &address.Base58{75, data}
-	addr := address.ToBase58(payload)
-	if addr != base58address {
-		t.Errorf("TestToBase58: base58 encoding error")
+	for _, addr := range addresses {
+		base58, err := FromBase58(addr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		gotAddr := ToBase58(base58)
+		assert.Equal(t, addr, gotAddr)
 	}
 }
 
 func TestBech32(t *testing.T) {
-	bech32, err := address.FromBech32(bech32address)
-	if err != nil {
-		t.Errorf("TestFromBech32: bech32 decoding error")
-	}
-	if bech32.Prefix != "ert" {
-		t.Errorf("TestFromBech32: wrong prefix")
-	}
-	if bech32.Version != 0 {
-		t.Errorf("TestFromBech32: wrong version")
-	}
-	if len(bech32.Program) != 33 && len(bech32.Program) != 20 {
-		t.Errorf("TestFromBech32: data size mismatch")
-	}
-	bc32, _ := address.ToBech32(&address.Bech32{bech32.Prefix, bech32.Version, bech32.Program})
-	if bc32 != bech32address {
-		t.Errorf("TestToBech32: wrong anddress")
+	addresses := []string{
+		"ert1qlg343tpldc4wvjxn3jdq2qs35r8j5yd5kjfrrt",
+		"ert1qyny4kp4adanuu670vfrnz7t384s8gvdtnwr0jcvvrwqwar4t9qcs2m7c20",
 	}
 
-}
-
-func TestToBlech32_P2WPKH(t *testing.T) {
-	pkBytes, err := hex.DecodeString(pubKey)
-	if err != nil {
-		t.Error(err)
-	}
-
-	witProg1Bytes, err := hex.DecodeString(witProg1)
-	if err != nil {
-		t.Error(err)
-	}
-
-	blech32Addr := &address.Blech32{
-		Prefix:    "el",
-		Version:   0,
-		PublicKey: pkBytes,
-		Program:   witProg1Bytes,
-	}
-
-	blech32, err := address.ToBlech32(blech32Addr)
-	if err != nil {
-		t.Error(err)
-	}
-
-	if addr1 != blech32 {
-		t.Error("TestToBlech32_P2WPKH: blech32 encoding error")
+	for _, addr := range addresses {
+		b32, err := FromBech32(addr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		gotAddr, err := ToBech32(b32)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, addr, gotAddr)
 	}
 }
 
-func TestToBlech32_P2WSH(t *testing.T) {
-	pkBytes, err := hex.DecodeString(pubKey)
-	if err != nil {
-		t.Error(err)
+func TestBase58Confidential(t *testing.T) {
+	addresses := []string{
+		"CTEvndySQ8VCBNmc7LGcGVm43eTqwWdCzFTSD7bjd4bJs7ti181aQnwADXXCzJPbANkSEpeVq19yck8N",
+		"AzppxC5RDs8yB8mabhwS13y4WbsWoS41fLV8GKM4woLUJB5RxNBVfK6wdVX4QVoubRXFKKfbPhEKKTKc",
 	}
 
-	witProg2Bytes, err := hex.DecodeString(witProg2)
-	if err != nil {
-		t.Error(err)
-	}
-
-	blech32Addr := &address.Blech32{
-		Prefix:    "el",
-		Version:   0,
-		PublicKey: pkBytes,
-		Program:   witProg2Bytes,
-	}
-
-	blech32, err := address.ToBlech32(blech32Addr)
-	if err != nil {
-		t.Error(err)
-	}
-
-	if addr2 != blech32 {
-		t.Error("TestToBlech32_P2WSH: blech32 encoding error")
+	for _, addr := range addresses {
+		base58, err := FromBase58Confidential(addr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		gotAddr := ToBase58Confidential(base58)
+		assert.Equal(t, addr, gotAddr)
 	}
 }
 
-func TestFromBlech32_P2WPKH(t *testing.T) {
-	blech32, err := address.FromBlech32(addr1)
-	if err != nil {
-		t.Error(err)
-	}
-	if blech32.Version != 0 {
-		t.Error("TestFromBlech32_P2WPKH: wrong version")
+func TestBlech32(t *testing.T) {
+	addresses := []string{
+		"el1qqw3e3mk4ng3ks43mh54udznuekaadh9lgwef3mwgzrfzakmdwcvqpe4ppdaa3t44v3zv2u6w56pv6tc666fvgzaclqjnkz0sd",
+		"el1qqw3e3mk4ng3ks43mh54udznuekaadh9lgwef3mwgzrfzakmdwcvqqve2xzutyaf7vjcap67f28q90uxec2ve95g3rpu5crapcmfr2l9xl5jzazvcpysz",
 	}
 
-	resPubKey := blech32.PublicKey
-	if hex.EncodeToString(resPubKey) != pubKey {
-		t.Error("TestFromBlech32_P2WPKH: wrong pub key")
-	}
-
-	resProgram := blech32.Program
-	if hex.EncodeToString(resProgram) != witProg1 {
-		t.Error("TestFromBlech32_P2WPKH: wrong witness program")
+	for _, addr := range addresses {
+		b32, err := FromBlech32(addr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		gotAddr, err := ToBlech32(b32)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, addr, gotAddr)
 	}
 }
 
-func TestFromBlech32_P2WSH(t *testing.T) {
-	blech32, err := address.FromBlech32(addr2)
-	if err != nil {
-		t.Error(err)
-	}
-	if blech32.Version != 0 {
-		t.Error("TestFromBlech32_P2WSH: wrong version")
-	}
-
-	resPubKey := blech32.PublicKey
-	if hex.EncodeToString(resPubKey) != pubKey {
-		t.Error("TestFromBlech32_P2WSH: wrong pub key")
+func TestConfidential(t *testing.T) {
+	addresses := []string{
+		"CTEvndySQ8VCBNmc7LGcGVm43eTqwWdCzFTSD7bjd4bJs7ti181aQnwADXXCzJPbANkSEpeVq19yck8N",
+		"AzppxC5RDs8yB8mabhwS13y4WbsWoS41fLV8GKM4woLUJB5RxNBVfK6wdVX4QVoubRXFKKfbPhEKKTKc",
+		"el1qqw3e3mk4ng3ks43mh54udznuekaadh9lgwef3mwgzrfzakmdwcvqpe4ppdaa3t44v3zv2u6w56pv6tc666fvgzaclqjnkz0sd",
+		"el1qqw3e3mk4ng3ks43mh54udznuekaadh9lgwef3mwgzrfzakmdwcvqqve2xzutyaf7vjcap67f28q90uxec2ve95g3rpu5crapcmfr2l9xl5jzazvcpysz",
 	}
 
-	resProgram := blech32.Program
-	if hex.EncodeToString(resProgram) != witProg2 {
-		t.Error("TestFromBlech32_P2WSH: wrong witness program")
+	for _, addr := range addresses {
+		res, err := FromConfidential(addr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		gotAddr, err := ToConfidential(res)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, addr, gotAddr)
 	}
 }
 
-func TestDecodeAddressTypeP2Pkh(t *testing.T) {
-	addr := "Q9863Eah5byyxdBX8zghpooS2x4Ey8XZyc"
-	addressType, err := address.DecodeType(addr, network.Liquid)
-	if err != nil {
-		t.Fatal(err)
+func TestDecodeAddressType(t *testing.T) {
+	tests := []struct {
+		address      string
+		network      network.Network
+		expectedType int
+	}{
+		{
+			address:      "Q9863Eah5byyxdBX8zghpooS2x4Ey8XZyc",
+			network:      network.Liquid,
+			expectedType: P2Pkh,
+		},
+		{
+			address:      "H5RCjtzndKyzFnVe41yg62T3WViWguyz4M",
+			network:      network.Liquid,
+			expectedType: P2Sh,
+		},
+		{
+			address:      "ex1qlg343tpldc4wvjxn3jdq2qs35r8j5yd5vqrmu3",
+			network:      network.Liquid,
+			expectedType: P2Wpkh,
+		},
+		{
+			address:      "ert1q2z45rh444qmeand48lq0wp3jatxs2nzh492ds9s5yscv2pplxwesajz7q3",
+			network:      network.Regtest,
+			expectedType: P2Wsh,
+		},
+		{
+			address:      "VTpuLYhJwE8CFm6h1A6DASCaJuRQqkBt6qGfbebSHAUxGXsJMo8wtRvLZYZSWWXt89jG55pCF4YfxMjh",
+			network:      network.Liquid,
+			expectedType: ConfidentialP2Pkh,
+		},
+		{
+			address:      "VJLDHFUbw8oPUcwzmf9jw4tZdN57rEfAusRmWy6knHAF2a4rLGenJz5WPVuyggVzQPHY6JjzKuw31B6e",
+			network:      network.Liquid,
+			expectedType: ConfidentialP2Sh,
+		},
+		{
+			address:      "lq1qqwrdmhm69vsq3qfym06tlyhfze9ltauay9tv4r34ueplfwtjx0q27dk2c4d3a9ms6wum04efclqph7dg4unwcmwmw4vnqreq3",
+			network:      network.Liquid,
+			expectedType: ConfidentialP2Wpkh,
+		},
+		{
+			address:      "lq1qq2akvug2el2rg6lt6aewh9rzy7dglf9ajdmrkknnwwl3jwxgfkh985x3lrzmrq2mc3c6aa85wgxxfm9v8r062qwq4ty579p54pn2q2hqnhgwv394ycf8",
+			network:      network.Liquid,
+			expectedType: ConfidentialP2Wsh,
+		},
 	}
-	assert.Equal(t, address.P2Pkh, addressType)
+
+	for _, tt := range tests {
+		addressType, err := DecodeType(tt.address, tt.network)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, tt.expectedType, addressType)
+	}
 }
 
-func TestDecodeAddressTypeP2sh(t *testing.T) {
-	addr := "H5RCjtzndKyzFnVe41yg62T3WViWguyz4M"
-	addressType, err := address.DecodeType(addr, network.Liquid)
-	if err != nil {
-		t.Fatal(err)
-	}
-	assert.Equal(t, address.P2Sh, addressType)
-}
-
-func TestDecodeAddressTypeConfidentialP2Pkh(t *testing.T) {
-	addr := "VTpuLYhJwE8CFm6h1A6DASCaJuRQqkBt6qGfbebSHAUxGXsJMo8wtRvLZYZSWWXt8" +
-		"9jG55pCF4YfxMjh"
-	addressType, err := address.DecodeType(addr, network.Liquid)
-	if err != nil {
-		t.Fatal(err)
-	}
-	assert.Equal(t, address.ConfidentialP2Pkh, addressType)
-}
-
-func TestDecodeAddressTypeConfidentialP2sh(t *testing.T) {
-	addr := "VJLDHFUbw8oPUcwzmf9jw4tZdN57rEfAusRmWy6knHAF2a4rLGenJz5WPVuyggVzQ" +
-		"PHY6JjzKuw31B6e"
-	addressType, err := address.DecodeType(addr, network.Liquid)
-	if err != nil {
-		t.Fatal(err)
-	}
-	assert.Equal(t, address.ConfidentialP2Sh, addressType)
-}
-
-func TestDecodeAddressTypeP2wpkh(t *testing.T) {
-	addr := "ex1qlg343tpldc4wvjxn3jdq2qs35r8j5yd5vqrmu3"
-
-	addressType, err := address.DecodeType(addr, network.Liquid)
-	if err != nil {
-		t.Fatal(err)
-	}
-	assert.Equal(t, address.P2Wpkh, addressType)
-}
-
-func TestDecodeAddressTypeConfidentialP2wpkh(t *testing.T) {
-	addr := "lq1qqwrdmhm69vsq3qfym06tlyhfze9ltauay9tv4r34ueplfwtjx0q27dk2c4d3a" +
-		"9ms6wum04efclqph7dg4unwcmwmw4vnqreq3"
-	addressType, err := address.DecodeType(addr, network.Liquid)
-	if err != nil {
-		t.Fatal(err)
-	}
-	assert.Equal(t, address.ConfidentialP2Wpkh, addressType)
-}
-
-func TestDecodeAddressTypeP2wsh(t *testing.T) {
-	addr := "ert1q2z45rh444qmeand48lq0wp3jatxs2nzh492ds9s5yscv2pplxwesajz7q3"
-	addressType, err := address.DecodeType(addr, network.Regtest)
-	if err != nil {
-		t.Fatal(err)
-	}
-	assert.Equal(t, address.P2Wsh, addressType)
-}
-
-func TestDecodeAddressTypeConfidentialP2wsh(t *testing.T) {
-	addr := "lq1qq2akvug2el2rg6lt6aewh9rzy7dglf9ajdmrkknnwwl3jwxgfkh985x3lrzmr" +
-		"q2mc3c6aa85wgxxfm9v8r062qwq4ty579p54pn2q2hqnhgwv394ycf8"
-	addressType, err := address.DecodeType(addr, network.Liquid)
-	if err != nil {
-		t.Fatal(err)
-	}
-	assert.Equal(t, address.ConfidentialP2Wsh, addressType)
+func h2b(str string) []byte {
+	buf, _ := hex.DecodeString(str)
+	return buf
 }


### PR DESCRIPTION
This adds the methods `FromBase58Confidential` and `ToBase58Confidential` useful for the user to parse confidential legay P2PKH and P2SH addresses, like `FromBlech32` and `ToBlech32` do for those bech32 confidentials.

This also adds 2 new methods `FromConfidential` and `ToConfidential` that help the user to convert an address from the confidential to the unconfidential format and viceversa.

The last method added with this is `NetworkFromAddress` that is useful for knowing the network (either mainnet or regtest) an address refers to.

In conclusion, this refactors the tests for the address package to increase order and readability, along with adding tests for the new methods mentioned above.

Please @tiero, review this.