### PR TITLE
Move to go-secp256k1-zkp v1.1.0

### DIFF
--- a/confidential/confidential.go
+++ b/confidential/confidential.go
@@ -420,7 +420,7 @@ func surjectionProof(args SurjectionProofArgs) ([]byte, bool) {
 		ctx,
 		fixedInputTags,
 		args.nInputsToUse(),
-		*fixedOutputTag,
+		fixedOutputTag,
 		maxIterations,
 		args.Seed,
 	)
@@ -432,7 +432,7 @@ func surjectionProof(args SurjectionProofArgs) ([]byte, bool) {
 		ctx,
 		proof,
 		inputGenerators,
-		*outputGenerator,
+		outputGenerator,
 		inputIndex,
 		args.InputAssetBlindingFactors[inputIndex],
 		args.OutputAssetBlindingFactor,
@@ -445,7 +445,7 @@ func surjectionProof(args SurjectionProofArgs) ([]byte, bool) {
 		ctx,
 		proof,
 		inputGenerators,
-		*outputGenerator,
+		outputGenerator,
 	) {
 		return nil, false
 	}
@@ -482,15 +482,15 @@ func verifySurjectionProof(args VerifySurjectionProofArgs) bool {
 		ctx,
 		proof,
 		inGenerators,
-		*outGenerator,
+		outGenerator,
 	)
 }
 
-func inAssetGenerators(inAssets, inAssetBlinders [][]byte) ([]secp256k1.Generator, error) {
+func inAssetGenerators(inAssets, inAssetBlinders [][]byte) ([]*secp256k1.Generator, error) {
 	ctx, _ := secp256k1.ContextCreate(secp256k1.ContextBoth)
 	defer secp256k1.ContextDestroy(ctx)
 
-	inGenerators := make([]secp256k1.Generator, 0, len(inAssets))
+	inGenerators := make([]*secp256k1.Generator, 0, len(inAssets))
 	for i, inAsset := range inAssets {
 		gen, err := secp256k1.GeneratorGenerateBlinded(
 			ctx,
@@ -500,7 +500,7 @@ func inAssetGenerators(inAssets, inAssetBlinders [][]byte) ([]secp256k1.Generato
 		if err != nil {
 			return nil, err
 		}
-		inGenerators = append(inGenerators, *gen)
+		inGenerators = append(inGenerators, gen)
 	}
 	return inGenerators, nil
 }
@@ -511,20 +511,20 @@ func outAssetGenerator(outAsset, outAssetBlinder []byte) (*secp256k1.Generator, 
 		return nil, err
 	}
 	outGenerator := res[0]
-	return &outGenerator, nil
+	return outGenerator, nil
 }
 
-func inFixedTags(inAssets [][]byte) ([]secp256k1.FixedAssetTag, error) {
+func inFixedTags(inAssets [][]byte) ([]*secp256k1.FixedAssetTag, error) {
 	ctx, _ := secp256k1.ContextCreate(secp256k1.ContextBoth)
 	defer secp256k1.ContextDestroy(ctx)
 
-	fixedInputTags := make([]secp256k1.FixedAssetTag, 0, len(inAssets))
+	fixedInputTags := make([]*secp256k1.FixedAssetTag, 0, len(inAssets))
 	for _, inTag := range inAssets {
 		fixedAssetTag, err := secp256k1.FixedAssetTagParse(inTag)
 		if err != nil {
 			return nil, err
 		}
-		fixedInputTags = append(fixedInputTags, *fixedAssetTag)
+		fixedInputTags = append(fixedInputTags, fixedAssetTag)
 	}
 	return fixedInputTags, nil
 }
@@ -535,7 +535,7 @@ func outFixedTag(outAsset []byte) (*secp256k1.FixedAssetTag, error) {
 		return nil, err
 	}
 	outFixedTag := res[0]
-	return &outFixedTag, nil
+	return outFixedTag, nil
 }
 
 func calcAssetHash(in *transaction.TxInput) ([]byte, error) {

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,6 @@ require (
 	github.com/btcsuite/btcutil/psbt v1.0.2
 	github.com/stretchr/testify v1.5.1
 	github.com/vulpemventures/fastsha256 v0.0.0-20160815193821-637e65642941
-	github.com/vulpemventures/go-secp256k1-zkp v1.0.2
+	github.com/vulpemventures/go-secp256k1-zkp v1.1.0
 	golang.org/x/crypto v0.0.0-20200115085410-6d4e4cb37c7d
 )

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/vulpemventures/fastsha256 v0.0.0-20160815193821-637e65642941 h1:CTcw8
 github.com/vulpemventures/fastsha256 v0.0.0-20160815193821-637e65642941/go.mod h1:GXBJykxW2kUcktGdsgyay7uwwWvkljASfljNcT0mbh8=
 github.com/vulpemventures/go-secp256k1-zkp v1.0.2 h1:K8zh2NegPd3JzZXWMv+ikWPHx/yZkIZH+LjOKGYYvzA=
 github.com/vulpemventures/go-secp256k1-zkp v1.0.2/go.mod h1:zo7CpgkuPgoe7fAV+inyxsI9IhGmcoFgyD8nqZaPSOM=
+github.com/vulpemventures/go-secp256k1-zkp v1.1.0 h1:Z3qKc/lYxEQ1cukwwjD4n7EBCrg7N6of4hylVsD+lOA=
+github.com/vulpemventures/go-secp256k1-zkp v1.1.0/go.mod h1:zo7CpgkuPgoe7fAV+inyxsI9IhGmcoFgyD8nqZaPSOM=
 golang.org/x/crypto v0.0.0-20170930174604-9419663f5a44/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200115085410-6d4e4cb37c7d h1:2+ZP7EfsZV7Vvmx3TIqSlSzATMkTAKqM14YGFPoSKjI=


### PR DESCRIPTION
This contains changes to use the latest version of go-secp256k1-zkp (v1.1.0 - [`0d0930e1`](https://github.com/vulpemventures/go-secp256k1-zkp/commit/0d0930e13ab9f7badf79211e0c651c623a6c74f5)) that fixes the bug that was affecting the surjection proof's verification.

Please @tiero, review this.