### PR TITLE
gomobile bind: Allow go-elements to be built for Android and iOS targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@
 
 # WebStorm IDE project config files
 .idea
+
+*.aar
+*.framework

--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,7 @@
 # WebStorm IDE project config files
 .idea
 
+# gomobile artifacts
 *.aar
+*.jar
 *.framework

--- a/README.md
+++ b/README.md
@@ -31,27 +31,6 @@ $ go get github.com/vulpemventures/go-elements@latest
 - [Broadcast issuance transaction - with unblinded inputs, blinded issuance, blinded outputs](pset/pset_test.go#L867)
 
 
-## 📱 Build for mobile targets
-
-
-* Android 
-
-If you are not using Android Studio, in order to work with bindings for Android, you need to have Android SDK installed and ANDROID_HOME environment variable set to the SDK path. You also need the NDK installed;
-
-```sh
-$ export CGO_ENABLED=1
-$ gomobile init
-$ gomobile bind -target android -o elements.aar ./address ./slip77 ./payment ./network ./confidential ./transaction ./pset
-```
-
-* iOS
-
-It requires the host machine to be running macOS.
-
-```sh
-$ export CGO_ENABLED=1
-$ gomobile init
-$ gomobile bind -target ios -o elements.framework ./address ./slip77 ./payment ./network ./confidential ./transaction ./pset
 ```
 
 ## 🛣 Roadmap
@@ -75,6 +54,30 @@ $ gomobile bind -target ios -o elements.framework ./address ./slip77 ./payment .
 - [x] Asset re-issuance
 - [x] Slip77
 - [ ] Upcoming [PSET spec](https://github.com/ElementsProject/elements/pull/951) support
+
+
+## 📱 Build for mobile
+
+
+* Android 
+
+If you are not using Android Studio, in order to work with bindings for Android, you need to have Android SDK installed and ANDROID_HOME environment variable set to the SDK path. You also need the NDK installed;
+
+```sh
+$ export CGO_ENABLED=1
+$ gomobile init
+$ gomobile bind -target android -o elements.aar ./address ./slip77 ./payment ./network ./confidential ./transaction ./pset
+```
+
+* iOS
+
+It requires the host machine to be running macOS.
+
+```sh
+$ export CGO_ENABLED=1
+$ gomobile init
+$ gomobile bind -target ios -o elements.framework ./address ./slip77 ./payment ./network ./confidential ./transaction ./pset
+
 
 ## 🖥 Development
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,30 @@ $ go get github.com/vulpemventures/go-elements@latest
 - [Broadcast issuance transaction - with unblinded inputs, unblinded issuance, blinded outputs](pset/pset_test.go#L689)
 - [Broadcast issuance transaction - with unblinded inputs, blinded issuance, blinded outputs](pset/pset_test.go#L867)
 
+
+## 📱 Build for mobile targets
+
+
+* Android 
+
+If you are not using Android Studio, in order to work with bindings for Android, you need to have Android SDK installed and ANDROID_HOME environment variable set to the SDK path. You also need the NDK installed;
+
+```sh
+$ export CGO_ENABLED=1
+$ gomobile init
+$ gomobile bind -target android -o elements.aar ./address ./slip77 ./payment ./network ./confidential ./transaction ./pset
+```
+
+* iOS
+
+It requires the host machine to be running macOS.
+
+```sh
+$ export CGO_ENABLED=1
+$ gomobile init
+$ gomobile bind -target ios -o elements.framework ./address ./slip77 ./payment ./network ./confidential ./transaction ./pset
+```
+
 ## 🛣 Roadmap
 
 - [x] Chain parameters (prefixes, magic numbers, …)

--- a/blech32/blech32.go
+++ b/blech32/blech32.go
@@ -10,21 +10,6 @@ const charset = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
 //new generators, 7 bytes compared to bech32
 var gen = []int64{0x7d52fba40bd886, 0x5e8dbf1a03950c, 0x1c3a3c74072a18, 0x385d72fa0e5139, 0x7093e5a608865b}
 
-// For more details on the polymod calculation, please refer to BIP 173.
-func blech32Polymod(values []int) int64 {
-	chk := int64(1)
-	for _, v := range values {
-		b := chk >> 55                                           //25->55 compared to bech32
-		chk = (chk&int64(0x7fffffffffffff))<<int64(5) ^ int64(v) //0x1ffffff->0x7fffffffffffff compared to bech32
-		for i := 0; i < 5; i++ {
-			if (b>>uint(i))&1 == 1 {
-				chk ^= gen[i]
-			}
-		}
-	}
-	return chk
-}
-
 // Decode decodes a blech32 encoded string, returning the human-readable
 // part and the data part excluding the checksum.
 func Decode(blech string) (string, []byte, error) {
@@ -221,6 +206,21 @@ func blech32Checksum(hrp string, data []byte) []byte {
 		res = append(res, byte((polymod>>uint(5*(11-i)))&31)) //5 -> 11 compared to bech32
 	}
 	return res
+}
+
+// For more details on the polymod calculation, please refer to BIP 173.
+func blech32Polymod(values []int) int64 {
+	chk := int64(1)
+	for _, v := range values {
+		b := chk >> 55                                           //25->55 compared to bech32
+		chk = (chk&int64(0x7fffffffffffff))<<int64(5) ^ int64(v) //0x1ffffff->0x7fffffffffffff compared to bech32
+		for i := 0; i < 5; i++ {
+			if (b>>uint(i))&1 == 1 {
+				chk ^= gen[i]
+			}
+		}
+	}
+	return chk
 }
 
 // For more details on HRP expansion, please refer to BIP 173.

--- a/blech32/blech32.go
+++ b/blech32/blech32.go
@@ -8,7 +8,22 @@ import (
 const charset = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
 
 //new generators, 7 bytes compared to bech32
-var gen = []int{0x7d52fba40bd886, 0x5e8dbf1a03950c, 0x1c3a3c74072a18, 0x385d72fa0e5139, 0x7093e5a608865b}
+var gen = []int64{0x7d52fba40bd886, 0x5e8dbf1a03950c, 0x1c3a3c74072a18, 0x385d72fa0e5139, 0x7093e5a608865b}
+
+// For more details on the polymod calculation, please refer to BIP 173.
+func blech32Polymod(values []int) int64 {
+	chk := int64(1)
+	for _, v := range values {
+		b := chk >> 55                                           //25->55 compared to bech32
+		chk = (chk&int64(0x7fffffffffffff))<<int64(5) ^ int64(v) //0x1ffffff->0x7fffffffffffff compared to bech32
+		for i := 0; i < 5; i++ {
+			if (b>>uint(i))&1 == 1 {
+				chk ^= gen[i]
+			}
+		}
+	}
+	return chk
+}
 
 // Decode decodes a blech32 encoded string, returning the human-readable
 // part and the data part excluding the checksum.
@@ -206,21 +221,6 @@ func blech32Checksum(hrp string, data []byte) []byte {
 		res = append(res, byte((polymod>>uint(5*(11-i)))&31)) //5 -> 11 compared to bech32
 	}
 	return res
-}
-
-// For more details on the polymod calculation, please refer to BIP 173.
-func blech32Polymod(values []int) int {
-	chk := 1
-	for _, v := range values {
-		b := chk >> 55                      //25->55 compared to bech32
-		chk = (chk&0x7fffffffffffff)<<5 ^ v //0x1ffffff->0x7fffffffffffff compared to bech32
-		for i := 0; i < 5; i++ {
-			if (b>>uint(i))&1 == 1 {
-				chk ^= gen[i]
-			}
-		}
-	}
-	return chk
 }
 
 // For more details on HRP expansion, please refer to BIP 173.

--- a/pset/doc.go
+++ b/pset/doc.go
@@ -1,67 +1,6 @@
-// Copyright (c) 2013-2017 The btcsuite developers
-// Copyright (c) 2015-2016 The Decred developers
-// Copyright (c) 2019-2020 The VulpemVentures developers
-
-// A modification of the BIP-174 standard for Partial Signed Elements Transaction.
-// (https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki)
-package pset
-
-// This type is for GoDoc documentation purposes only.
-// It explains on a deeper level how to use the PSET package correctly.
-//
-// This package is designed in order to apply the possible fewer changes to the reference
-// spec so that it can be used for Elements unblinded and blinded transactions.
-// Essentially this version of partial transaction uses an underlying Elements unsigned
-// transaction instead of a Bitcoin one, and the partial input WitnessUtxo field represents
-// an Elements output rather than a Bitcoin one.
-//
-// NOTE: The Elements implementation of PSET is under development at the moment (take a look here)
-// and this package will likely change in the future to adapt to this standard.
-type PSET_PACKAGE int
-
-// The creator is an exported factory function named simply New with the following signature:
-//   func New(inputs []*transaction.TxInput, outputs []*transaction.TxOutput, version int32, nLockTime uint32) (*Pset, error) {}
-// The role of this function is to simply create an unsigned partial transaction with the given inputs, outputs, version and locktime.
-// The unblinded asset and amounts of the outputs are encoded into the "unsigned tx" field of the partial transaction.
-func ROLE_1_Creator() *PSET_PACKAGE { return nil }
-
-// The updater, as the name suggests, has the responsibility of updating the fields of any partial input or output.
-// It consists of a collection of methods that, basically, has the purpose of adding any new field to an existing partial
-// input (included issuance or reissuance placed in the unsigned tx) or output.
-// It also allows to add new inputs or outputs to the underlying unsigned transaction.
-// The updater can be instantiated by calling the NewUpdater factory function passing a partial transasction object.
-func ROLE_2_Updater() *PSET_PACKAGE { return nil }
-
-// At the moment the blinder role is designed to blind ALL the outputs of the partial transaction but
-// this will change soon, letting one to blind only the set of outputs he wants.
-// Also, this version of the blinder requires that all the private keys necessary
-// to unblind all the confidential inputs used must be provided.
-// Given this, the pset package is not useful in case multiple parties want to
-// create a transaction by joining their inputs/outputs since they would need to
-// reveal their blinding private keys and share them with the one encharged of assuming the blinder role.
-// The pset package will change in the future to support the use case mentioned before, but this is not yet planned in the development.
-func ROLE_3_Blinder() *PSET_PACKAGE { return nil }
-
-// The signer is in charge of checking that when adding a signature to an input of the pset,
-// this is valid and that also the pset is correctly structured. Given that, this role is implemented
-// as a function Sign of the *Updater type. This function accepts an input index, a signature, a public key,
-// and one between a redeem or witness script and checks that the signature is valid against the given script and pubkey,
-// along with setting the partial input's signature script to the one provided.
-func ROLE_4_Signer() *PSET_PACKAGE { return nil }
-
-// The finalizer takes a partial transaction and combines every input's PartialSignature into the final input's
-// SignatureScript. After finalizing, the partial transaction is complete, and it's ready to be extracted from the
-// Pset wrapper and broadcasted to the network. This role is accomplished by a Finalize function that accepts a *Pset
-//instance and an input index, and performs the operations described above, returning an error if any occurs during the process.
-//It previously checks that the provided partial transaction is valid in the sense that it's ready to be finalized; otherwise,
-// an error is returned. A handy FinalizeAll that runs the above method for every input of the provided *Pset is also exported.
-func ROLE_5_Finalizer() *PSET_PACKAGE { return nil }
-
-// The extractor is a simple Extract function expecting a finalized partial transaction that returns the final signed
-// transaction by adding the signatures of the partial inputs to the underlying unsigned transaction.
-func ROLE_6_Extractor() *PSET_PACKAGE { return nil }
-
 /*
+Package pset is a modification of the BIP-174 standard for Partial Signed Elements Transaction. (https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki)
+
 This is an exemplification on how to perform a P2WPKH transaction using the PSET package
 with the assistance of vulpemventures/nigiri for funding the address, retrieving the UTXOs and broadcasting.
 
@@ -181,4 +120,4 @@ with the assistance of vulpemventures/nigiri for funding the address, retrieving
 		t.Fatal("Expected transaction to be broadcasted")
 	}
 */
-func TX_P2WPKH() *PSET_PACKAGE { return nil }
+package pset

--- a/pset/pset.go
+++ b/pset/pset.go
@@ -217,16 +217,6 @@ func NewPsetFromUnsignedTx(tx *transaction.Transaction) (*Pset, error) {
 	return &retPset, nil
 }
 
-// NewPsetFromHex returns a new Pset from serialized pset in hex encoiding.
-func NewPsetFromHex(psetHex string) (*Pset, error) {
-	psetBytes, err := hex.DecodeString(psetHex)
-	if err != nil {
-		return nil, err
-	}
-	r := bytes.NewReader(psetBytes)
-	return deserialize(r)
-}
-
 // NewPsetFromBase64 returns a new Pset from a serialized pset in base64 encoding
 func NewPsetFromBase64(psetBase64 string) (*Pset, error) {
 	psetBytes, err := base64.StdEncoding.DecodeString(psetBase64)

--- a/pset/pset_test.go
+++ b/pset/pset_test.go
@@ -66,18 +66,6 @@ func TestRoundTrip(t *testing.T) {
 		}
 		assert.Equal(t, str, res)
 	}
-
-	for _, str := range tests.hex {
-		p, err := NewPsetFromHex(str)
-		if err != nil {
-			t.Fatal(err)
-		}
-		res, err := p.ToHex()
-		if err != nil {
-			t.Fatal(err)
-		}
-		assert.Equal(t, str, res)
-	}
 }
 
 func TestBroadcastBlindedSwapTx(t *testing.T) {

--- a/pset/pset_test.go
+++ b/pset/pset_test.go
@@ -1209,7 +1209,7 @@ func TestBroadcastBlindedIssuanceAndReIssuanceTx(t *testing.T) {
 	)
 
 	issuanceBlindPrvKeys := []IssuanceBlindingPrivateKeys{
-		IssuanceBlindingPrivateKeys{
+		{
 			AssetKey: outBlindingPrvKeysForIssuance[1],
 			TokenKey: outBlindingPrvKeysForIssuance[2],
 		},

--- a/slip77/slip77.go
+++ b/slip77/slip77.go
@@ -15,8 +15,15 @@ var (
 	prefix = byte(0)
 )
 
+//Slip77 holds the Master Blinding Key
 type Slip77 struct {
 	MasterKey []byte
+}
+
+//KeyPair holds a *btcec.PrivateKey and a *btcec.PublicKey
+type KeyPair struct {
+	PrivateKey *btcec.PrivateKey
+	PublicKey  *btcec.PublicKey
 }
 
 // FromMasterKey sets the provided master key to the returned instance of Slip77
@@ -51,12 +58,12 @@ func FromSeed(seed []byte) (*Slip77, error) {
 
 // DeriveKey derives a private key from the master key of the Slip77 type
 // and a provided script
-func (s *Slip77) DeriveKey(script []byte) (*btcec.PrivateKey, *btcec.PublicKey, error) {
+func (s *Slip77) DeriveKey(script []byte) (*KeyPair, error) {
 	if s.MasterKey == nil || len(s.MasterKey) <= 0 {
-		return nil, nil, errors.New("master key must be defined")
+		return nil, errors.New("master key must be defined")
 	}
 	if script == nil || len(script) <= 0 {
-		return nil, nil, errors.New("invalid script")
+		return nil, errors.New("invalid script")
 	}
 
 	hmacKey := hmac.New(sha256.New, s.MasterKey)
@@ -65,5 +72,5 @@ func (s *Slip77) DeriveKey(script []byte) (*btcec.PrivateKey, *btcec.PublicKey, 
 
 	privateKey, publicKey := btcec.PrivKeyFromBytes(btcec.S256(), key)
 
-	return privateKey, publicKey, nil
+	return &KeyPair{privateKey, publicKey}, nil
 }

--- a/slip77/slip77_test.go
+++ b/slip77/slip77_test.go
@@ -49,13 +49,13 @@ func TestDeriveKey(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		privKey, pubKey, err := slip77Node.DeriveKey(script)
+		keyPair, err := slip77Node.DeriveKey(script)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		serializedPrivKey := hex.EncodeToString(privKey.Serialize())
-		serializedPubKey := hex.EncodeToString(pubKey.SerializeCompressed())
+		serializedPrivKey := hex.EncodeToString(keyPair.PrivateKey.Serialize())
+		serializedPubKey := hex.EncodeToString(keyPair.PublicKey.SerializeCompressed())
 
 		assert.Equal(
 			t,

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -369,10 +369,18 @@ func (tx *Transaction) WitnessHash() chainhash.Hash {
 	return tx.TxHash()
 }
 
+// IssuanceDetails holds the number of issuances, reissuances and the total of two combined
+type IssuanceDetails struct {
+	Issuances   int
+	Reissuances int
+	Total       int
+}
+
 // CountIssuances returns the number issuances contained in the transaction
 // as the number of issuances, reissuances and the total (their sum).
-func (tx *Transaction) CountIssuances() (issuances, reissuances, total int) {
-
+func (tx *Transaction) CountIssuances() *IssuanceDetails {
+	issuances := 0
+	reissuances := 0
 	for _, in := range tx.Inputs {
 		if in.HasIssuance() {
 			issuances++
@@ -381,8 +389,12 @@ func (tx *Transaction) CountIssuances() (issuances, reissuances, total int) {
 			reissuances++
 		}
 	}
-	total = issuances + reissuances
-	return
+	total := issuances + reissuances
+	return &IssuanceDetails{
+		Issuances:   issuances,
+		Reissuances: reissuances,
+		Total:       total,
+	}
 }
 
 // Weight returns the total weight in bytes of the transaction


### PR DESCRIPTION
This commit allows to build `go-elements` packages as a single standalone library to be imported in iOS and Android targets using `gomobile bind`

To do so some cosmetic change is needed to make it work, most importantly we have Only a subset of Go types wich are currently supported and return variables should be at maximum 2 where the second shoudl alwasy be the `error`

The only breaking change has been for the `slip77` where `DeriveKey` now it returns a struct `KeyPair` instead of two variables. 

I see this as an acceptable tradeoff overall, instead of creating dedicated slip77 gomobile binding.


