### PR TITLE
global xpub: remove hdkeychain parse check

### DIFF
--- a/psetv2/global.go
+++ b/psetv2/global.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/vulpemventures/go-elements/internal/bufferutil"
 
-	"github.com/btcsuite/btcd/btcutil/base58"
 	"github.com/btcsuite/btcd/btcutil/hdkeychain"
 )
 
@@ -286,11 +285,6 @@ func (g *Global) deserialize(buf *bytes.Buffer) error {
 		case GlobalXpub:
 			if len(kp.Key.KeyData) != pubKeyLength+1 {
 				return ErrGlobalInvalidXPubLen
-			}
-			// Parse xpub to make sure it's valid
-			xpubStr := base58.Encode(kp.Key.KeyData[1:])
-			if _, err := hdkeychain.NewKeyFromString(xpubStr); err != nil {
-				return err
 			}
 
 			if len(kp.Value) == 0 || len(kp.Value)%4 != 0 {

--- a/psetv2/global.go
+++ b/psetv2/global.go
@@ -297,7 +297,7 @@ func (g *Global) deserialize(buf *bytes.Buffer) error {
 			}
 
 			g.Xpubs = append(g.Xpubs, Xpub{
-				ExtendedKey:       kp.Key.KeyData,
+				ExtendedKey:       kp.Key.KeyData[1:],
 				MasterFingerprint: master,
 				DerivationPath:    derivationPath,
 			})

--- a/psetv2/input.go
+++ b/psetv2/input.go
@@ -1210,7 +1210,7 @@ func (i *Input) deserialize(buf *bytes.Buffer) error {
 					return ErrInDuplicatedField("taproot script signature")
 				}
 			}
-			if len(kp.Value) != 64 || len(kp.Value) != 65 {
+			if len(kp.Value) != 64 && len(kp.Value) != 65 {
 				return ErrInInvalidTapScriptSigSignature
 			}
 			i.TapScriptSig = append(i.TapScriptSig, TapScriptSig{


### PR DESCRIPTION
remove the hdkeychain `NewKeyFromString` check while decoding a Global xpub.

@altafan please review