### PR TITLE
Hotfix unsafe usage of input prevout

### DIFF
--- a/psetv2/blinder.go
+++ b/psetv2/blinder.go
@@ -230,8 +230,11 @@ func (i OwnedInput) validate(p *Pset) error {
 	if int(i.Index) > int(p.Global.InputCount)-1 {
 		return ErrInputIndexOutOfRange
 	}
-	prevOut := p.Inputs[i.Index].GetUtxo()
-	if !prevOut.IsConfidential() {
+	prevout := p.Inputs[i.Index].GetUtxo()
+	if prevout == nil {
+		return fmt.Errorf("missing input prevout")
+	}
+	if !prevout.IsConfidential() {
 		return nil
 	}
 	if i.Value == 0 {
@@ -486,7 +489,11 @@ func (b *Blinder) validateBlindingArgs(
 			asset = buf[1:]
 			assetBlinder = ownedIn.AssetBlinder
 		} else {
-			asset = in.GetUtxo().Asset
+			prevout := in.GetUtxo()
+			if prevout == nil {
+				return fmt.Errorf("missing input prevout")
+			}
+			asset = prevout.Asset
 			assetBlinder = zeroBlinder
 		}
 		inAssets = append(inAssets, asset)

--- a/psetv2/input.go
+++ b/psetv2/input.go
@@ -381,6 +381,9 @@ func (i *Input) GetIssuanceInflationKeysHash() []byte {
 }
 
 func (i *Input) GetUtxo() *transaction.TxOutput {
+	if i.WitnessUtxo == nil && i.NonWitnessUtxo == nil {
+		return nil
+	}
 	utxo := i.WitnessUtxo
 	if utxo == nil {
 		utxo = i.NonWitnessUtxo.Outputs[i.PreviousTxIndex]


### PR DESCRIPTION
This makes the `input.GetUtxo()` api safe and fixes the unsafe usage that was made of it until now.

Please @tiero review